### PR TITLE
Allow trailing comma

### DIFF
--- a/src/file-handler.js
+++ b/src/file-handler.js
@@ -10,7 +10,9 @@ const _loadConfigFromFile = async (fileUri, readFile) => {
     return undefined;
   }
   const errors = [];
-  const config = jsoncParser.parse(contents.toString(), errors, { allowTrailingComma: true });
+  const config = jsoncParser.parse(contents.toString(), errors, {
+    allowTrailingComma: true,
+  });
   if (errors.length > 0) {
     throw new Error(`Failed to parse contents of: ${fileUri.fsPath}`);
   }

--- a/src/file-handler.js
+++ b/src/file-handler.js
@@ -10,7 +10,7 @@ const _loadConfigFromFile = async (fileUri, readFile) => {
     return undefined;
   }
   const errors = [];
-  const config = jsoncParser.parse(contents.toString(), errors);
+  const config = jsoncParser.parse(contents.toString(), errors, { allowTrailingComma: true });
   if (errors.length > 0) {
     throw new Error(`Failed to parse contents of: ${fileUri.fsPath}`);
   }


### PR DESCRIPTION
Passing this option to the jsonc-parser module allows for trailing comma's in the `settings.local.json` and `settings.shared.json` files.
This would also solve #89.

Not entirely sure how your tests are setup and the contributing guide is empty, so I'll leave it up to you if you want to add tests :)