### PR TITLE
Add deep merging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.2.4",
       "license": "MIT",
       "dependencies": {
+        "deepmerge": "^4.3.0",
         "jsonc-parser": "^3.2.0"
       },
       "devDependencies": {
@@ -852,6 +853,14 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.0.tgz",
+      "integrity": "sha512-z2wJZXrmeHdvYJp/Ux55wIjqo81G5Bp4c+oELTW+7ar6SogWHajt5a9gO3s3IDaGSAXjDk0vlQKN3rms8ab3og==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/delegates": {
       "version": "1.0.0",
@@ -4087,6 +4096,11 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
+    },
+    "deepmerge": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.0.tgz",
+      "integrity": "sha512-z2wJZXrmeHdvYJp/Ux55wIjqo81G5Bp4c+oELTW+7ar6SogWHajt5a9gO3s3IDaGSAXjDk0vlQKN3rms8ab3og=="
     },
     "delegates": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,8 @@
     "vsce": "^2.15.0"
   },
   "dependencies": {
-    "jsonc-parser": "^3.2.0"
+    "jsonc-parser": "^3.2.0",
+    "deepmerge": "^4.3.0"
   },
   "scripts": {
     "build": "npm test",

--- a/src/file-handler.js
+++ b/src/file-handler.js
@@ -2,6 +2,7 @@
 
 const { isDeepStrictEqual } = require('util');
 const jsoncParser = require('jsonc-parser');
+const deepMerge = require('deepmerge');
 const log = require('./log');
 
 const _loadConfigFromFile = async (fileUri, readFile) => {
@@ -46,7 +47,7 @@ const mergeConfigFiles = async ({
       vscodeFileUri,
       readFile
     );
-    const merged = { ...sharedFileContents, ...localFileContents };
+    const merged = deepMerge(sharedFileContents, localFileContents);
 
     // Avoid rewriting the file if there are no changes to be applied
     if (isDeepStrictEqual(vscodeFileContents, merged)) {

--- a/src/file-handler.js
+++ b/src/file-handler.js
@@ -58,7 +58,7 @@ const mergeConfigFiles = async ({
     await writeFile(
       vscodeFileUri,
       Buffer.from(
-        JSON.stringify({ ...vscodeFileContents, ...merged }, null, 2)
+        JSON.stringify(deepMerge(vscodeFileContents, merged), null, 2)
       ),
       { create: true, overwrite: true }
     );

--- a/tests/unit/file-handler.js
+++ b/tests/unit/file-handler.js
@@ -2,6 +2,7 @@
 
 const { assert } = require('chai');
 const jsoncParser = require('jsonc-parser');
+const deepMerge = require('deepmerge');
 const Sinon = require('sinon');
 
 const { callbacks } = require('../data');
@@ -83,13 +84,46 @@ suite('file handler Suite', () => {
     const sharedFileUri = { path: '.vscode/settings.shared.json' };
     const localFileUri = { path: '.vscode/settings.local.json' };
     const mergeConfigFiles = fileHandler.mergeConfigFiles;
-    const sharedConfig = { foo: false };
-    const localConfig = { foo: true, 'window.zoomLevel': 1, baz: false };
-    const vscodeConfig = { foo: 'abc', 'window.zoomLevel': 0, bar: 'def' };
+    const sharedConfig = {
+      foo: false,
+      'editor.rulers': [
+        100,
+      ],
+      '[typescript]': {
+        'editor.dragAndDrop': false,
+        'editor.tabCompletion': 'on',
+      },
+    };
+    const localConfig = {
+      foo: true,
+      'window.zoomLevel': 1,
+      'editor.rulers': [
+        80,
+      ],
+      '[typescript]': {
+        'editor.dragAndDrop': true,
+        'editor.autoIndent': false,
+      },
+      baz: false,
+    };
+    const vscodeConfig = {
+      foo: 'abc',
+      'window.zoomLevel': 0,
+      bar: 'def',
+    };
     const expConfig = {
       foo: true,
       'window.zoomLevel': 1,
       bar: 'def',
+      'editor.rulers': [
+        100,
+        80,
+      ],
+      '[typescript]': {
+        'editor.dragAndDrop': true,
+        'editor.tabCompletion': 'on',
+        'editor.autoIndent': false,
+      },
       baz: false,
     };
 

--- a/tests/unit/file-handler.js
+++ b/tests/unit/file-handler.js
@@ -86,9 +86,7 @@ suite('file handler Suite', () => {
     const mergeConfigFiles = fileHandler.mergeConfigFiles;
     const sharedConfig = {
       foo: false,
-      'editor.rulers': [
-        100,
-      ],
+      'editor.rulers': [100],
       '[typescript]': {
         'editor.dragAndDrop': false,
         'editor.tabCompletion': 'on',
@@ -97,9 +95,7 @@ suite('file handler Suite', () => {
     const localConfig = {
       foo: true,
       'window.zoomLevel': 1,
-      'editor.rulers': [
-        80,
-      ],
+      'editor.rulers': [80],
       '[typescript]': {
         'editor.dragAndDrop': true,
         'editor.autoIndent': false,
@@ -115,10 +111,7 @@ suite('file handler Suite', () => {
       foo: true,
       'window.zoomLevel': 1,
       bar: 'def',
-      'editor.rulers': [
-        100,
-        80,
-      ],
+      'editor.rulers': [100, 80],
       '[typescript]': {
         'editor.dragAndDrop': true,
         'editor.tabCompletion': 'on',

--- a/tests/unit/file-handler.js
+++ b/tests/unit/file-handler.js
@@ -131,7 +131,7 @@ suite('file handler Suite', () => {
       loadConfigFromFileStub
         .withArgs(vscodeFileUri, callbacks.readFile)
         .callsFake(() => {
-          return Promise.resolve({ ...sharedConfig, ...localConfig });
+          return Promise.resolve(deepMerge(sharedConfig, localConfig));
         });
       await mergeConfigFiles({
         vscodeFileUri,


### PR DESCRIPTION
Hi!

I've started to use the extension but I encountered one issue - instead of deep merging config files (like VS Code does with `User -> Folder` settings), it merges them in a flat way. Example:

_settings.shared.json_
```
{
  "[typescript]": {
    "editor.tabSize": 4,
    "editor.tabCompletion": "on"
  }
}
```

_settings.local.json_
```
{
  "[typescript]": {
    "editor.tabCompletion": "off"
  }
}
```

_settings.json_
```
{
  "[typescript]": {
    "editor.tabCompletion": "off"
  }
}
```

This PR changes this behavior so settings.json would look like this:
```
{
  "[typescript]": {
    "editor.tabSize": 4,
    "editor.tabCompletion": "off"
  }
}
```

Please let me know if it makes sense for you :)

Cheers!