### PR TITLE
Allow users to control array merge behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,24 @@
         "fileMatch": "/.vscode/tasks.local.json",
         "url": "vscode://schemas/tasks"
       }
-    ]
+    ],
+    "configuration": {
+      "type": "object",
+      "title": "Workspace Config+",
+      "properties": {
+        "workspaceConfigPlus.arrayMerge": {
+          "description": "Defines the merge behavior to use for arrays",
+          "type": "string",
+          "scope": "resource",
+          "default": "combine",
+          "enum": ["combine", "overwrite"],
+          "enumDescriptions": [
+            "Performs a deep merge of array-type properties overlapping in both local and shared user settings, where the arrays are combined",
+            "If both the local and shared files define a value for the same array-type property, then the array value in the local file is used and the shared array value is ignored"
+          ]
+        }
+      }
+    }
   },
   "keywords": [
     "local settings",

--- a/tests/unit/config.js
+++ b/tests/unit/config.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const { assert } = require('chai');
+
+const fileHandler = require('../../src/file-handler');
+const {
+  contributes: { configuration },
+} = require('../../package.json');
+const { properties: config } = configuration;
+
+suite('config Suite', () => {
+  test('Should have the correct number of configuration settings', () => {
+    assert.deepEqual(Object.keys(config).length, 1);
+  });
+
+  test('Should have correct config setting values for array merge behavior', () => {
+    const arrayMergeConfig = config[fileHandler._arrayMergeKey];
+    assert.deepEqual(
+      arrayMergeConfig.default,
+      fileHandler._arrayMergeDefaultValue
+    );
+    assert.deepEqual(arrayMergeConfig.enum, ['combine', 'overwrite']);
+  });
+});

--- a/tests/unit/file-handler.js
+++ b/tests/unit/file-handler.js
@@ -2,11 +2,10 @@
 
 const { assert } = require('chai');
 const jsoncParser = require('jsonc-parser');
-const deepMerge = require('deepmerge');
 const Sinon = require('sinon');
 
 const { callbacks } = require('../data');
-const fileHandler = require('../..//src/file-handler');
+const fileHandler = require('../../src/file-handler');
 const log = require('../../src/log');
 
 suite('file handler Suite', () => {
@@ -73,6 +72,8 @@ suite('file handler Suite', () => {
     /** @type {Sinon.SinonStub} */
     let loadConfigFromFileStub;
     /** @type {Sinon.SinonStub} */
+    let loadVSConfigFromFileStub;
+    /** @type {Sinon.SinonStub} */
     let writeFileStub;
     /** @type {Sinon.SinonStub} */
     let logInfoStub;
@@ -84,15 +85,21 @@ suite('file handler Suite', () => {
     const sharedFileUri = { path: '.vscode/settings.shared.json' };
     const localFileUri = { path: '.vscode/settings.local.json' };
     const mergeConfigFiles = fileHandler.mergeConfigFiles;
-    const sharedConfig = {
+    const vscodeConfig = {
+      foo: 'abc',
+      'window.zoomLevel': 0,
+      bar: 'def',
+    };
+    const sharedArrayCombineConfig = {
       foo: false,
       'editor.rulers': [100],
       '[typescript]': {
         'editor.dragAndDrop': false,
         'editor.tabCompletion': 'on',
       },
+      [fileHandler._arrayMergeKey]: 'combine',
     };
-    const localConfig = {
+    const localArrayCombineConfig = {
       foo: true,
       'window.zoomLevel': 1,
       'editor.rulers': [80],
@@ -101,36 +108,88 @@ suite('file handler Suite', () => {
         'editor.autoIndent': false,
       },
       baz: false,
+      [fileHandler._arrayMergeKey]: 'combine',
     };
-    const vscodeConfig = {
-      foo: 'abc',
-      'window.zoomLevel': 0,
-      bar: 'def',
-    };
-    const expConfig = {
+
+    const expArrayCombineConfig = {
       foo: true,
       'window.zoomLevel': 1,
-      bar: 'def',
       'editor.rulers': [100, 80],
       '[typescript]': {
         'editor.dragAndDrop': true,
         'editor.tabCompletion': 'on',
         'editor.autoIndent': false,
       },
+      [fileHandler._arrayMergeKey]: 'combine',
+      baz: false,
+    };
+    const finalExpArrayCombineConfig = {
+      ...vscodeConfig,
+      ...expArrayCombineConfig,
+    };
+    const expArrayCombineConfigNoExplicitMerge = JSON.parse(
+      JSON.stringify(finalExpArrayCombineConfig)
+    );
+    delete expArrayCombineConfigNoExplicitMerge[fileHandler._arrayMergeKey];
+
+    const sharedArrayOverwriteConfig = {
+      foo: false,
+      'editor.rulers': [100],
+      '[typescript]': {
+        'editor.dragAndDrop': false,
+        'editor.tabCompletion': 'on',
+      },
+      // Note the casing in the value, added intentionally to provide
+      // defensive testing and ensure we aren't pedantic about case.
+      [fileHandler._arrayMergeKey]: 'OVERwrite',
+    };
+    const sharedConfigNoArrayMerge = JSON.parse(
+      JSON.stringify(sharedArrayOverwriteConfig)
+    );
+    delete sharedConfigNoArrayMerge[fileHandler._arrayMergeKey];
+    const localArrayOverwriteConfig = {
+      foo: true,
+      'window.zoomLevel': 1,
+      'editor.rulers': [80],
+      '[typescript]': {
+        'editor.dragAndDrop': true,
+        'editor.autoIndent': false,
+      },
+      [fileHandler._arrayMergeKey]: 'overwrite',
+      baz: false,
+    };
+    const localConfigNoArrayMerge = JSON.parse(
+      JSON.stringify(localArrayOverwriteConfig)
+    );
+    delete localConfigNoArrayMerge[fileHandler._arrayMergeKey];
+    const expArrayOverwriteConfig = {
+      foo: true,
+      'window.zoomLevel': 1,
+      bar: 'def',
+      'editor.rulers': [80],
+      '[typescript]': {
+        'editor.dragAndDrop': true,
+        'editor.tabCompletion': 'on',
+        'editor.autoIndent': false,
+      },
+      [fileHandler._arrayMergeKey]: 'overwrite',
       baz: false,
     };
 
     setup(() => {
       loadConfigFromFileStub = Sinon.stub(fileHandler, '_loadConfigFromFile');
+      loadVSConfigFromFileStub = loadConfigFromFileStub.withArgs(
+        vscodeFileUri,
+        callbacks.readFile
+      );
       loadConfigFromFileStub
         .withArgs(sharedFileUri, callbacks.readFile)
-        .callsFake(() => Promise.resolve(sharedConfig));
+        .callsFake(() => Promise.resolve(sharedArrayCombineConfig));
       loadConfigFromFileStub
         .withArgs(localFileUri, callbacks.readFile)
-        .callsFake(() => Promise.resolve(localConfig));
-      loadConfigFromFileStub
-        .withArgs(vscodeFileUri, callbacks.readFile)
-        .callsFake(() => Promise.resolve(vscodeConfig));
+        .callsFake(() => Promise.resolve(localArrayCombineConfig));
+
+      loadVSConfigFromFileStub.callsFake(() => Promise.resolve(vscodeConfig));
       writeFileStub = Sinon.stub(callbacks, 'writeFile');
       logDebugStub = Sinon.stub(log, 'debug');
       logErrorStub = Sinon.stub(log, 'error');
@@ -155,11 +214,9 @@ suite('file handler Suite', () => {
     });
 
     test('Should return early when there are no changes to be made', async () => {
-      loadConfigFromFileStub
-        .withArgs(vscodeFileUri, callbacks.readFile)
-        .callsFake(() => {
-          return Promise.resolve(deepMerge(sharedConfig, localConfig));
-        });
+      loadVSConfigFromFileStub.callsFake(() => {
+        return Promise.resolve(expArrayCombineConfig);
+      });
       await mergeConfigFiles({
         vscodeFileUri,
         sharedFileUri,
@@ -190,7 +247,11 @@ suite('file handler Suite', () => {
         writeFileStub.calledOnceWithExactly(
           vscodeFileUri,
           Buffer.from(
-            JSON.stringify({ ...vscodeConfig, ...sharedConfig }, null, 2)
+            JSON.stringify(
+              { ...vscodeConfig, ...sharedArrayCombineConfig },
+              null,
+              2
+            )
           ),
           { create: true, overwrite: true }
         )
@@ -217,14 +278,18 @@ suite('file handler Suite', () => {
         writeFileStub.calledOnceWithExactly(
           vscodeFileUri,
           Buffer.from(
-            JSON.stringify({ ...vscodeConfig, ...localConfig }, null, 2)
+            JSON.stringify(
+              { ...vscodeConfig, ...localArrayCombineConfig },
+              null,
+              2
+            )
           ),
           { create: true, overwrite: true }
         )
       );
     });
 
-    test('Should write to config file with correct priority order', async () => {
+    test('Should write to config file with correct priority order using array combine', async () => {
       await mergeConfigFiles({
         vscodeFileUri,
         sharedFileUri,
@@ -240,7 +305,141 @@ suite('file handler Suite', () => {
       assert.isTrue(
         writeFileStub.calledOnceWithExactly(
           vscodeFileUri,
-          Buffer.from(JSON.stringify(expConfig, null, 2)),
+          Buffer.from(JSON.stringify(finalExpArrayCombineConfig, null, 2)),
+          { create: true, overwrite: true }
+        )
+      );
+    });
+
+    test('Should write to config file with correct priority order using shared array overwrite', async () => {
+      loadConfigFromFileStub
+        .withArgs(sharedFileUri, callbacks.readFile)
+        .callsFake(() => Promise.resolve(sharedArrayOverwriteConfig));
+      loadConfigFromFileStub
+        .withArgs(localFileUri, callbacks.readFile)
+        .callsFake(() => Promise.resolve(localArrayCombineConfig));
+      await mergeConfigFiles({
+        vscodeFileUri,
+        sharedFileUri,
+        localFileUri,
+        ...callbacks,
+      });
+      assert.isTrue(loadConfigFromFileStub.calledThrice);
+      assert.isTrue(
+        logInfoStub.calledOnceWithExactly(
+          `Updating config in ${vscodeFileUri.fsPath}`
+        )
+      );
+      assert.isTrue(
+        writeFileStub.calledOnceWithExactly(
+          vscodeFileUri,
+          Buffer.from(JSON.stringify(finalExpArrayCombineConfig, null, 2)),
+          { create: true, overwrite: true }
+        )
+      );
+    });
+
+    test('Should write to config file with correct priority order using shared array overwrite', async () => {
+      loadConfigFromFileStub
+        .withArgs(localFileUri, callbacks.readFile)
+        .callsFake(() => Promise.resolve(localArrayOverwriteConfig));
+      await mergeConfigFiles({
+        vscodeFileUri,
+        sharedFileUri,
+        localFileUri,
+        ...callbacks,
+      });
+      assert.isTrue(loadConfigFromFileStub.calledThrice);
+      assert.isTrue(
+        logInfoStub.calledOnceWithExactly(
+          `Updating config in ${vscodeFileUri.fsPath}`
+        )
+      );
+      assert.isTrue(
+        writeFileStub.calledOnceWithExactly(
+          vscodeFileUri,
+          Buffer.from(JSON.stringify(expArrayOverwriteConfig, null, 2)),
+          { create: true, overwrite: true }
+        )
+      );
+    });
+
+    test('Should write to config file with correct priority order using correct array merge default', async () => {
+      loadConfigFromFileStub
+        .withArgs(sharedFileUri, callbacks.readFile)
+        .callsFake(() => Promise.resolve(sharedConfigNoArrayMerge));
+      loadConfigFromFileStub
+        .withArgs(localFileUri, callbacks.readFile)
+        .callsFake(() => Promise.resolve(localConfigNoArrayMerge));
+      await mergeConfigFiles({
+        vscodeFileUri,
+        sharedFileUri,
+        localFileUri,
+        ...callbacks,
+      });
+      assert.isTrue(loadConfigFromFileStub.calledThrice);
+      assert.isTrue(
+        logInfoStub.calledOnceWithExactly(
+          `Updating config in ${vscodeFileUri.fsPath}`
+        )
+      );
+      assert.isTrue(
+        writeFileStub.calledOnceWithExactly(
+          vscodeFileUri,
+          Buffer.from(
+            JSON.stringify(expArrayCombineConfigNoExplicitMerge, null, 2)
+          ),
+          { create: true, overwrite: true }
+        )
+      );
+    });
+
+    test('Should maintain idempotency for unmodified settings', async () => {
+      loadVSConfigFromFileStub.onSecondCall().callsFake(() => {
+        return Promise.resolve(finalExpArrayCombineConfig);
+      });
+      const updatedLocalConfig = JSON.parse(
+        JSON.stringify(localArrayCombineConfig)
+      );
+      updatedLocalConfig.cow = 'moo';
+      const secondExpectedConfig = JSON.parse(
+        JSON.stringify(finalExpArrayCombineConfig)
+      );
+      secondExpectedConfig.cow = 'moo';
+      loadConfigFromFileStub
+        .withArgs(localFileUri, callbacks.readFile)
+        .onSecondCall()
+        .callsFake(() => Promise.resolve(updatedLocalConfig));
+      await mergeConfigFiles({
+        vscodeFileUri,
+        sharedFileUri,
+        localFileUri,
+        ...callbacks,
+      });
+      await mergeConfigFiles({
+        vscodeFileUri,
+        sharedFileUri,
+        localFileUri,
+        ...callbacks,
+      });
+
+      assert.deepEqual(loadConfigFromFileStub.callCount, 6);
+      assert.isTrue(logInfoStub.calledTwice);
+      assert.isTrue(
+        logInfoStub.calledWith(`Updating config in ${vscodeFileUri.fsPath}`)
+      );
+      assert.isTrue(writeFileStub.calledTwice);
+      assert.isTrue(
+        writeFileStub.firstCall.calledWithExactly(
+          vscodeFileUri,
+          Buffer.from(JSON.stringify(finalExpArrayCombineConfig, null, 2)),
+          { create: true, overwrite: true }
+        )
+      );
+      assert.isTrue(
+        writeFileStub.secondCall.calledWithExactly(
+          vscodeFileUri,
+          Buffer.from(JSON.stringify(secondExpectedConfig, null, 2)),
           { create: true, overwrite: true }
         )
       );
@@ -257,6 +456,44 @@ suite('file handler Suite', () => {
       });
       assert.isTrue(logErrorStub.calledOnceWithExactly(err.message));
       assert.isTrue(logDebugStub.calledOnceWithExactly(err));
+    });
+
+    test('Throws correct error on invalid type for array merge behavior', async () => {
+      const arrayMerge = 2;
+      const invalidArrayMergeTypeConfig = JSON.parse(
+        JSON.stringify(localArrayCombineConfig)
+      );
+      invalidArrayMergeTypeConfig[fileHandler._arrayMergeKey] = arrayMerge;
+      loadConfigFromFileStub
+        .withArgs(localFileUri, callbacks.readFile)
+        .callsFake(() => Promise.resolve(invalidArrayMergeTypeConfig));
+      const expErrMessage = `Invalid value for 'arrayMerge' setting: '${arrayMerge}'. Must be 'overwrite' or 'combine'`;
+      await mergeConfigFiles({
+        vscodeFileUri,
+        sharedFileUri,
+        localFileUri,
+        ...callbacks,
+      });
+      assert.isTrue(logErrorStub.calledOnceWithExactly(expErrMessage));
+    });
+
+    test('Throws correct error on invalid value for array merge behavior', async () => {
+      const arrayMerge = 'shuffle';
+      const invalidArrayMergeValueConfig = JSON.parse(
+        JSON.stringify(localArrayCombineConfig)
+      );
+      invalidArrayMergeValueConfig[fileHandler._arrayMergeKey] = arrayMerge;
+      loadConfigFromFileStub
+        .withArgs(localFileUri, callbacks.readFile)
+        .callsFake(() => Promise.resolve(invalidArrayMergeValueConfig));
+      const expErrMessage = `Invalid value for 'arrayMerge' setting: '${arrayMerge}'. Must be 'overwrite' or 'combine'`;
+      await mergeConfigFiles({
+        vscodeFileUri,
+        sharedFileUri,
+        localFileUri,
+        ...callbacks,
+      });
+      assert.isTrue(logErrorStub.calledOnceWithExactly(expErrMessage));
     });
   });
 });


### PR DESCRIPTION
Will use this to close #111 and close #112. #108 could arguably be closed by this as well (at least in so far as my original intent), however, won't explicitly close that since #108 has evolved into a much more holistic question.

Hopefully self-evident in the PR title, but this allows users to control the deep merging behavior added in #107, and also fixes an idempotency bug introduced as part of that initial deep merge support.

As noted in some subsequent comments on #108, the core need with deep merging post #107 is to allow users to specify what happens with arrays because an unconfigurable deep merge behavior takes away the ability to use the extension to override/unset any and all array elements specified in *.shared.json files.

I think the combine/deep merge behavior makes sense as the default (even if it is a significant behavioral change), but we need this knob to continue to be able to offer current behavior to support the alternative.

Finally, this initial implementation does _not_ honor the user/machine level setting. That's entirely doable, but I'm deferring that to a future PR, both to avoid making this one any larger and because workspace-level setting support is sufficient for me to feel comfortable releasing the deep merge behavior.