### PR TITLE
feat: replace merged symlinks option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+build/
 node_modules/
 .testresults/
 .coverage/

--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,3 +1,5 @@
+plugins:
+  - prettier-plugin-jsdoc
 singleQuote: true
 bracketSpacing: true
 endOfLine: lf

--- a/.vscode/settings.shared.json
+++ b/.vscode/settings.shared.json
@@ -15,5 +15,6 @@
   "[yaml]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
+  "mochaExplorer.configFile": "tests/unit/.mocharc.yml",
   "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/.vscode/settings.shared.json
+++ b/.vscode/settings.shared.json
@@ -1,0 +1,19 @@
+{
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "typescript.suggest.jsdoc.generateReturns": true
+  },
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[markdown]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[yaml]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/.vscode/tasks.shared.json
+++ b/.vscode/tasks.shared.json
@@ -1,0 +1,24 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "typescript",
+      "tsconfig": "tsconfig.json",
+      "problemMatcher": [
+        "$tsc"
+      ],
+      "group": "build",
+      "label": "tsc: build - tsconfig.json"
+    },
+    {
+      "type": "typescript",
+      "tsconfig": "tsconfig.json",
+      "option": "watch",
+      "problemMatcher": [
+        "$tsc-watch"
+      ],
+      "group": "build",
+      "label": "tsc: watch - tsconfig.json"
+    }
+  ]
+}

--- a/.vscode/tasks.shared.json
+++ b/.vscode/tasks.shared.json
@@ -4,6 +4,9 @@
     {
       "type": "typescript",
       "tsconfig": "tsconfig.json",
+      "options": {
+        "build": "",
+      },
       "problemMatcher": [
         "$tsc"
       ],
@@ -14,6 +17,9 @@
       "type": "typescript",
       "tsconfig": "tsconfig.json",
       "option": "watch",
+      "options": {
+        "build": "",
+      },
       "problemMatcher": [
         "$tsc-watch"
       ],

--- a/base.tsconfig.json
+++ b/base.tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
-    "rootDir": ".",
-    "outDir": "build"
+    "emitDeclarationOnly": true,
+    "outDir": "build",
+    "rootDir": "."
   },
   "exclude": ["./node_modules", "./.vscode-test"]
 }

--- a/base.tsconfig.json
+++ b/base.tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "exclude": ["./node_modules", "./.vscode-test"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,11 @@
       },
       "devDependencies": {
         "@swellaby/eslint-config": "^2.0.0",
+        "@types/chai": "^4.3.5",
+        "@types/mocha": "^10.0.1",
+        "@types/node": "^18",
+        "@types/sinon": "^10.0.16",
+        "@types/vscode": "^1.49.0",
         "c8": "^8.0.1",
         "chai": "^4.3.7",
         "eslint": "^8.46.0",
@@ -21,8 +26,10 @@
         "mocha-multi-reporters": "^1.5.1",
         "mocha-sonarqube-reporter": "^1.0.2",
         "prettier": "^3.0.1",
+        "prettier-plugin-jsdoc": "^1.0.1",
         "rimraf": "^5.0.1",
         "sinon": "^15.2.0",
+        "typescript": "^5.1.6",
         "vsce": "^2.15.0"
       },
       "engines": {
@@ -362,10 +369,79 @@
         "eslint": ">=3.0.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.5.tgz",
+      "integrity": "sha512-mEo1sAde+UCE6b2hxn332f1g1E8WfYRu6p5SvTKr2ZKC1f7gFJXk4h5PyGP9Dt6gCaG8y8XhwnXWC6Iy2cmBng==",
+      "dev": true
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.8.tgz",
+      "integrity": "sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
       "integrity": "sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==",
+      "dev": true
+    },
+    "node_modules/@types/mdast": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.12.tgz",
+      "integrity": "sha512-DT+iNIRNX884cx0/Q1ja7NyUPpZuv0KPyL5rGNxm1WC1OtHstl7n4Jb7nk+xacNShQMbczJjt8uFzznpp6kYBg==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^2"
+      }
+    },
+    "node_modules/@types/mocha": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.1.tgz",
+      "integrity": "sha512-/fvYntiO1GeICvqbQ3doGDIP97vWmvFt83GKguJ6prmQM2iXZfFcq6YE8KteFyRtX2/h5Hf91BYvPodJKFYv5Q==",
+      "dev": true
+    },
+    "node_modules/@types/ms": {
+      "version": "0.7.31",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "18.17.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.5.tgz",
+      "integrity": "sha512-xNbS75FxH6P4UXTPUJp/zNPq6/xsfdJKussCWNOnz4aULWIRwMgP1LgaB5RiBnMX1DPCYenuqGZfnIAx5mbFLA==",
+      "dev": true
+    },
+    "node_modules/@types/sinon": {
+      "version": "10.0.16",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.16.tgz",
+      "integrity": "sha512-j2Du5SYpXZjJVJtXBokASpPRj+e2z+VUhCPHmM6WMfe3dpHu6iVKJMU6AiBcMp/XTAYnEj6Wc1trJUWwZ0QaAQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "node_modules/@types/sinonjs__fake-timers": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.2.tgz",
+      "integrity": "sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA==",
+      "dev": true
+    },
+    "node_modules/@types/unist": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.7.tgz",
+      "integrity": "sha512-cputDpIbFgLUaGQn6Vqg3/YsJwxUwHLO13v3i5ouxT4lat0khip9AEWxtERujXV9wxIB1EyF97BSJFt6vpdI8g==",
+      "dev": true
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.81.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.81.0.tgz",
+      "integrity": "sha512-YIaCwpT+O2E7WOMq0eCgBEABE++SX3Yl/O02GoMIF2DO3qAtvw7m6BXFYsxnc6XyzwZgh6/s/UG78LSSombl2w==",
       "dev": true
     },
     "node_modules/acorn": {
@@ -526,6 +602,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/binary-searching": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/binary-searching/-/binary-searching-2.0.5.tgz",
+      "integrity": "sha512-v4N2l3RxL+m4zDxyxz3Ne2aTmiPn8ZUpKFpdPtO+ItW1NcTCXA7JeHG5GMBSvoKSkQZ9ycS+EouDVxYB9ufKWA==",
+      "dev": true
     },
     "node_modules/bl": {
       "version": "4.1.0",
@@ -792,6 +874,16 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
@@ -941,6 +1033,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/comment-parser": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.0.tgz",
+      "integrity": "sha512-QLyTNiZ2KDOibvFPlZ6ZngVsZ/0gYnE6uTXi5aoDg8ed3AkJAz4sEje3Y8a29hQ1s6A99MZXe47fLAXQ1rTqaw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1051,6 +1152,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.0.2.tgz",
+      "integrity": "sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==",
+      "dev": true,
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/decompress-response": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
@@ -1103,6 +1217,15 @@
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
       "dev": true
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/detect-libc": {
       "version": "1.0.3",
@@ -2054,6 +2177,15 @@
         "prebuild-install": "^6.0.0"
       }
     },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -2195,11 +2327,490 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.3.1.tgz",
+      "integrity": "sha512-4xTO/M8c82qBcnQc1tgpNtubGUW/Y1tBQ1B0i5CtSoelOLKFYlElIr3bvgREYYO5iRqbMY1YuqZng0GVOI8Qww==",
+      "dev": true,
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "@types/unist": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "mdast-util-to-string": "^3.1.0",
+        "micromark": "^3.0.0",
+        "micromark-util-decode-numeric-character-reference": "^1.0.0",
+        "micromark-util-decode-string": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "unist-util-stringify-position": "^3.0.0",
+        "uvu": "^0.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.2.0.tgz",
+      "integrity": "sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==",
+      "dev": true,
+      "dependencies": {
+        "@types/mdast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdurl": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
       "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
       "dev": true
+    },
+    "node_modules/micromark": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-3.2.0.tgz",
+      "integrity": "sha512-uD66tJj54JLYq0De10AhWycZWGQNUvDI55xPgk2sQM5kn1JYlhbCMTtEeT27+vAhW2FBQxLlOmS3pmA7/2z4aA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-core-commonmark": "^1.0.1",
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-combine-extensions": "^1.0.0",
+        "micromark-util-decode-numeric-character-reference": "^1.0.0",
+        "micromark-util-encode": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "micromark-util-resolve-all": "^1.0.0",
+        "micromark-util-sanitize-uri": "^1.0.0",
+        "micromark-util-subtokenize": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.1",
+        "uvu": "^0.5.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-1.1.0.tgz",
+      "integrity": "sha512-BgHO1aRbolh2hcrzL2d1La37V0Aoz73ymF8rAcKnohLy93titmv62E0gP8Hrx9PKcKrqCZ1BbLGbP3bEhoXYlw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-factory-destination": "^1.0.0",
+        "micromark-factory-label": "^1.0.0",
+        "micromark-factory-space": "^1.0.0",
+        "micromark-factory-title": "^1.0.0",
+        "micromark-factory-whitespace": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-classify-character": "^1.0.0",
+        "micromark-util-html-tag-name": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "micromark-util-resolve-all": "^1.0.0",
+        "micromark-util-subtokenize": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.1",
+        "uvu": "^0.5.0"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-1.1.0.tgz",
+      "integrity": "sha512-XaNDROBgx9SgSChd69pjiGKbV+nfHGDPVYFs5dOoDd7ZnMAE+Cuu91BCpsY8RT2NP9vo/B8pds2VQNCLiu0zhg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-1.1.0.tgz",
+      "integrity": "sha512-OLtyez4vZo/1NjxGhcpDSbHQ+m0IIGnT8BoPamh+7jVlzLJBH98zzuCoUeMxvM6WsNeh8wx8cKvqLiPHEACn0w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-1.1.0.tgz",
+      "integrity": "sha512-cRzEj7c0OL4Mw2v6nwzttyOZe8XY/Z8G0rzmWQZTBi/jjwyw/U4uqKtUORXQrR5bAZZnbTI/feRV/R7hc4jQYQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-1.1.0.tgz",
+      "integrity": "sha512-J7n9R3vMmgjDOCY8NPw55jiyaQnH5kBdV2/UXCtZIpnHH3P6nHUKaH7XXEYuWwx/xUJcawa8plLBEjMPU24HzQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-1.1.0.tgz",
+      "integrity": "sha512-v2WlmiymVSp5oMg+1Q0N1Lxmt6pMhIHD457whWM7/GUlEks1hI9xj5w3zbc4uuMKXGisksZk8DzP2UyGbGqNsQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-1.2.0.tgz",
+      "integrity": "sha512-lXraTwcX3yH/vMDaFWCQJP1uIszLVebzUa3ZHdrgxr7KEU/9mL4mVgCpGbyhvNLNlauROiNUq7WN5u7ndbY6xg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-1.1.0.tgz",
+      "integrity": "sha512-Ye01HXpkZPNcV6FiyoW2fGZDUw4Yc7vT0E9Sad83+bEDiCJ1uXu0S3mr8WLpsz3HaG3x2q0HM6CTuPdcZcluFQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-1.1.0.tgz",
+      "integrity": "sha512-SL0wLxtKSnklKSUplok1WQFoGhUdWYKggKUiqhX+Swala+BtptGCu5iPRc+xvzJ4PXE/hwM3FNXsfEVgoZsWbw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-1.1.0.tgz",
+      "integrity": "sha512-Q20sp4mfNf9yEqDL50WwuWZHUrCO4fEyeDCnMGmG5Pr0Cz15Uo7KBs6jq+dq0EgX4DPwwrh9m0X+zPV1ypFvUA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-1.1.0.tgz",
+      "integrity": "sha512-m9V0ExGv0jB1OT21mrWcuf4QhP46pH1KkfWy9ZEezqHKAxkj4mPCy3nIH1rkbdMlChLHX531eOrymlwyZIf2iw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-1.1.0.tgz",
+      "integrity": "sha512-YphLGCK8gM1tG1bd54azwyrQRjCFcmgj2S2GoJDNnh4vYtnL38JS8M4gpxzOPNyHdNEpheyWXCTnnTDY3N+NVQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-decode-numeric-character-reference": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-1.1.0.tgz",
+      "integrity": "sha512-EuEzTWSTAj9PA5GOAs992GzNh2dGQO52UvAbtSOMvXTxv3Criqb6IOzJUBCmEqrrXSblJIJBbFFv6zPxpreiJw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-1.2.0.tgz",
+      "integrity": "sha512-VTQzcuQgFUD7yYztuQFKXT49KghjtETQ+Wv/zUjGSGBioZnkA4P1XXZPT1FHeJA6RwRXSF47yvJ1tsJdoxwO+Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-1.1.0.tgz",
+      "integrity": "sha512-N+w5vhqrBihhjdpM8+5Xsxy71QWqGn7HYNUvch71iV2PM7+E3uWGox1Qp90loa1ephtCxG2ftRV/Conitc6P2Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-1.1.0.tgz",
+      "integrity": "sha512-b/G6BTMSg+bX+xVCshPTPyAu2tmA0E4X98NSR7eIbeC6ycCqCeE7wjfDIgzEbkzdEVJXRtOG4FbEm/uGbCRouA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-1.2.0.tgz",
+      "integrity": "sha512-QO4GXv0XZfWey4pYFndLUKEAktKkG5kZTdUNaTAkzbuJxn2tNBOr+QtxR2XpWaMhbImT2dPzyLrPXLlPhph34A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-encode": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-1.1.0.tgz",
+      "integrity": "sha512-kUQHyzRoxvZO2PuLzMt2P/dwVsTiivCK8icYTeR+3WgbuPqfHgPPy7nFKbeqRivBvn/3N3GBiNC+JRTMSxEC7A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-1.1.0.tgz",
+      "integrity": "sha512-uEjpEYY6KMs1g7QfJ2eX1SQEV+ZT4rUD3UcF6l57acZvLNK7PBZL+ty82Z1qhK1/yXIY4bdx04FKMgR0g4IAag==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-util-types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-1.1.0.tgz",
+      "integrity": "sha512-ukRBgie8TIAcacscVHSiddHjO4k/q3pnedmzMQ4iwDcK0FtFCohKOlFbaOL/mPgfnPsL3C1ZyxJa4sbWrBl3jg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
     },
     "node_modules/mime": {
       "version": "1.6.0",
@@ -2382,6 +2993,15 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ms": {
@@ -2757,6 +3377,23 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/prettier-plugin-jsdoc": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-jsdoc/-/prettier-plugin-jsdoc-1.0.1.tgz",
+      "integrity": "sha512-07q74MfX9m+xHK2+Lr4c+igiEzAKVDWhqkvlm65WoYJUlRiaV6STXcEtcZMhrPPYgNeQRgb9FJmgE/n+OI4MpQ==",
+      "dev": true,
+      "dependencies": {
+        "binary-searching": "^2.0.5",
+        "comment-parser": "^1.3.1",
+        "mdast-util-from-markdown": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=14.13.1 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "prettier": "^3.0.0"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -3042,6 +3679,18 @@
       ],
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/sade": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+      "dev": true,
+      "dependencies": {
+        "mri": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/safe-buffer": {
@@ -3504,6 +4153,19 @@
         "underscore": "^1.12.1"
       }
     },
+    "node_modules/typescript": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/uc.micro": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
@@ -3515,6 +4177,19 @@
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
       "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==",
       "dev": true
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
+      "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -3536,6 +4211,24 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
+    },
+    "node_modules/uvu": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.6.tgz",
+      "integrity": "sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==",
+      "dev": true,
+      "dependencies": {
+        "dequal": "^2.0.0",
+        "diff": "^5.0.0",
+        "kleur": "^4.0.3",
+        "sade": "^1.7.3"
+      },
+      "bin": {
+        "uvu": "bin.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.0.0",
@@ -4176,10 +4869,79 @@
       "dev": true,
       "requires": {}
     },
+    "@types/chai": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.5.tgz",
+      "integrity": "sha512-mEo1sAde+UCE6b2hxn332f1g1E8WfYRu6p5SvTKr2ZKC1f7gFJXk4h5PyGP9Dt6gCaG8y8XhwnXWC6Iy2cmBng==",
+      "dev": true
+    },
+    "@types/debug": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.8.tgz",
+      "integrity": "sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==",
+      "dev": true,
+      "requires": {
+        "@types/ms": "*"
+      }
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
       "integrity": "sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==",
+      "dev": true
+    },
+    "@types/mdast": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.12.tgz",
+      "integrity": "sha512-DT+iNIRNX884cx0/Q1ja7NyUPpZuv0KPyL5rGNxm1WC1OtHstl7n4Jb7nk+xacNShQMbczJjt8uFzznpp6kYBg==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "^2"
+      }
+    },
+    "@types/mocha": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.1.tgz",
+      "integrity": "sha512-/fvYntiO1GeICvqbQ3doGDIP97vWmvFt83GKguJ6prmQM2iXZfFcq6YE8KteFyRtX2/h5Hf91BYvPodJKFYv5Q==",
+      "dev": true
+    },
+    "@types/ms": {
+      "version": "0.7.31",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "18.17.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.5.tgz",
+      "integrity": "sha512-xNbS75FxH6P4UXTPUJp/zNPq6/xsfdJKussCWNOnz4aULWIRwMgP1LgaB5RiBnMX1DPCYenuqGZfnIAx5mbFLA==",
+      "dev": true
+    },
+    "@types/sinon": {
+      "version": "10.0.16",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.16.tgz",
+      "integrity": "sha512-j2Du5SYpXZjJVJtXBokASpPRj+e2z+VUhCPHmM6WMfe3dpHu6iVKJMU6AiBcMp/XTAYnEj6Wc1trJUWwZ0QaAQ==",
+      "dev": true,
+      "requires": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "@types/sinonjs__fake-timers": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.2.tgz",
+      "integrity": "sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA==",
+      "dev": true
+    },
+    "@types/unist": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.7.tgz",
+      "integrity": "sha512-cputDpIbFgLUaGQn6Vqg3/YsJwxUwHLO13v3i5ouxT4lat0khip9AEWxtERujXV9wxIB1EyF97BSJFt6vpdI8g==",
+      "dev": true
+    },
+    "@types/vscode": {
+      "version": "1.81.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.81.0.tgz",
+      "integrity": "sha512-YIaCwpT+O2E7WOMq0eCgBEABE++SX3Yl/O02GoMIF2DO3qAtvw7m6BXFYsxnc6XyzwZgh6/s/UG78LSSombl2w==",
       "dev": true
     },
     "acorn": {
@@ -4292,6 +5054,12 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true
+    },
+    "binary-searching": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/binary-searching/-/binary-searching-2.0.5.tgz",
+      "integrity": "sha512-v4N2l3RxL+m4zDxyxz3Ne2aTmiPn8ZUpKFpdPtO+ItW1NcTCXA7JeHG5GMBSvoKSkQZ9ycS+EouDVxYB9ufKWA==",
       "dev": true
     },
     "bl": {
@@ -4492,6 +5260,12 @@
         "supports-color": "^7.1.0"
       }
     },
+    "character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "dev": true
+    },
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
@@ -4605,6 +5379,12 @@
       "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
       "dev": true
     },
+    "comment-parser": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.0.tgz",
+      "integrity": "sha512-QLyTNiZ2KDOibvFPlZ6ZngVsZ/0gYnE6uTXi5aoDg8ed3AkJAz4sEje3Y8a29hQ1s6A99MZXe47fLAXQ1rTqaw==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -4693,6 +5473,15 @@
       "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
       "dev": true
     },
+    "decode-named-character-reference": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.0.2.tgz",
+      "integrity": "sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==",
+      "dev": true,
+      "requires": {
+        "character-entities": "^2.0.0"
+      }
+    },
     "decompress-response": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
@@ -4732,6 +5521,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+      "dev": true
+    },
+    "dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true
     },
     "detect-libc": {
@@ -5440,6 +6235,12 @@
         "prebuild-install": "^6.0.0"
       }
     },
+    "kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true
+    },
     "leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -5550,10 +6351,271 @@
         }
       }
     },
+    "mdast-util-from-markdown": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.3.1.tgz",
+      "integrity": "sha512-4xTO/M8c82qBcnQc1tgpNtubGUW/Y1tBQ1B0i5CtSoelOLKFYlElIr3bvgREYYO5iRqbMY1YuqZng0GVOI8Qww==",
+      "dev": true,
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "@types/unist": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "mdast-util-to-string": "^3.1.0",
+        "micromark": "^3.0.0",
+        "micromark-util-decode-numeric-character-reference": "^1.0.0",
+        "micromark-util-decode-string": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "unist-util-stringify-position": "^3.0.0",
+        "uvu": "^0.5.0"
+      }
+    },
+    "mdast-util-to-string": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.2.0.tgz",
+      "integrity": "sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==",
+      "dev": true,
+      "requires": {
+        "@types/mdast": "^3.0.0"
+      }
+    },
     "mdurl": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
       "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
+      "dev": true
+    },
+    "micromark": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-3.2.0.tgz",
+      "integrity": "sha512-uD66tJj54JLYq0De10AhWycZWGQNUvDI55xPgk2sQM5kn1JYlhbCMTtEeT27+vAhW2FBQxLlOmS3pmA7/2z4aA==",
+      "dev": true,
+      "requires": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-core-commonmark": "^1.0.1",
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-combine-extensions": "^1.0.0",
+        "micromark-util-decode-numeric-character-reference": "^1.0.0",
+        "micromark-util-encode": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "micromark-util-resolve-all": "^1.0.0",
+        "micromark-util-sanitize-uri": "^1.0.0",
+        "micromark-util-subtokenize": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.1",
+        "uvu": "^0.5.0"
+      }
+    },
+    "micromark-core-commonmark": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-1.1.0.tgz",
+      "integrity": "sha512-BgHO1aRbolh2hcrzL2d1La37V0Aoz73ymF8rAcKnohLy93titmv62E0gP8Hrx9PKcKrqCZ1BbLGbP3bEhoXYlw==",
+      "dev": true,
+      "requires": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-factory-destination": "^1.0.0",
+        "micromark-factory-label": "^1.0.0",
+        "micromark-factory-space": "^1.0.0",
+        "micromark-factory-title": "^1.0.0",
+        "micromark-factory-whitespace": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-classify-character": "^1.0.0",
+        "micromark-util-html-tag-name": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "micromark-util-resolve-all": "^1.0.0",
+        "micromark-util-subtokenize": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.1",
+        "uvu": "^0.5.0"
+      }
+    },
+    "micromark-factory-destination": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-1.1.0.tgz",
+      "integrity": "sha512-XaNDROBgx9SgSChd69pjiGKbV+nfHGDPVYFs5dOoDd7ZnMAE+Cuu91BCpsY8RT2NP9vo/B8pds2VQNCLiu0zhg==",
+      "dev": true,
+      "requires": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "micromark-factory-label": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-1.1.0.tgz",
+      "integrity": "sha512-OLtyez4vZo/1NjxGhcpDSbHQ+m0IIGnT8BoPamh+7jVlzLJBH98zzuCoUeMxvM6WsNeh8wx8cKvqLiPHEACn0w==",
+      "dev": true,
+      "requires": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      }
+    },
+    "micromark-factory-space": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-1.1.0.tgz",
+      "integrity": "sha512-cRzEj7c0OL4Mw2v6nwzttyOZe8XY/Z8G0rzmWQZTBi/jjwyw/U4uqKtUORXQrR5bAZZnbTI/feRV/R7hc4jQYQ==",
+      "dev": true,
+      "requires": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "micromark-factory-title": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-1.1.0.tgz",
+      "integrity": "sha512-J7n9R3vMmgjDOCY8NPw55jiyaQnH5kBdV2/UXCtZIpnHH3P6nHUKaH7XXEYuWwx/xUJcawa8plLBEjMPU24HzQ==",
+      "dev": true,
+      "requires": {
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "micromark-factory-whitespace": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-1.1.0.tgz",
+      "integrity": "sha512-v2WlmiymVSp5oMg+1Q0N1Lxmt6pMhIHD457whWM7/GUlEks1hI9xj5w3zbc4uuMKXGisksZk8DzP2UyGbGqNsQ==",
+      "dev": true,
+      "requires": {
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "micromark-util-character": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-1.2.0.tgz",
+      "integrity": "sha512-lXraTwcX3yH/vMDaFWCQJP1uIszLVebzUa3ZHdrgxr7KEU/9mL4mVgCpGbyhvNLNlauROiNUq7WN5u7ndbY6xg==",
+      "dev": true,
+      "requires": {
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "micromark-util-chunked": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-1.1.0.tgz",
+      "integrity": "sha512-Ye01HXpkZPNcV6FiyoW2fGZDUw4Yc7vT0E9Sad83+bEDiCJ1uXu0S3mr8WLpsz3HaG3x2q0HM6CTuPdcZcluFQ==",
+      "dev": true,
+      "requires": {
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "micromark-util-classify-character": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-1.1.0.tgz",
+      "integrity": "sha512-SL0wLxtKSnklKSUplok1WQFoGhUdWYKggKUiqhX+Swala+BtptGCu5iPRc+xvzJ4PXE/hwM3FNXsfEVgoZsWbw==",
+      "dev": true,
+      "requires": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "micromark-util-combine-extensions": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-1.1.0.tgz",
+      "integrity": "sha512-Q20sp4mfNf9yEqDL50WwuWZHUrCO4fEyeDCnMGmG5Pr0Cz15Uo7KBs6jq+dq0EgX4DPwwrh9m0X+zPV1ypFvUA==",
+      "dev": true,
+      "requires": {
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "micromark-util-decode-numeric-character-reference": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-1.1.0.tgz",
+      "integrity": "sha512-m9V0ExGv0jB1OT21mrWcuf4QhP46pH1KkfWy9ZEezqHKAxkj4mPCy3nIH1rkbdMlChLHX531eOrymlwyZIf2iw==",
+      "dev": true,
+      "requires": {
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "micromark-util-decode-string": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-1.1.0.tgz",
+      "integrity": "sha512-YphLGCK8gM1tG1bd54azwyrQRjCFcmgj2S2GoJDNnh4vYtnL38JS8M4gpxzOPNyHdNEpheyWXCTnnTDY3N+NVQ==",
+      "dev": true,
+      "requires": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-decode-numeric-character-reference": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "micromark-util-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-1.1.0.tgz",
+      "integrity": "sha512-EuEzTWSTAj9PA5GOAs992GzNh2dGQO52UvAbtSOMvXTxv3Criqb6IOzJUBCmEqrrXSblJIJBbFFv6zPxpreiJw==",
+      "dev": true
+    },
+    "micromark-util-html-tag-name": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-1.2.0.tgz",
+      "integrity": "sha512-VTQzcuQgFUD7yYztuQFKXT49KghjtETQ+Wv/zUjGSGBioZnkA4P1XXZPT1FHeJA6RwRXSF47yvJ1tsJdoxwO+Q==",
+      "dev": true
+    },
+    "micromark-util-normalize-identifier": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-1.1.0.tgz",
+      "integrity": "sha512-N+w5vhqrBihhjdpM8+5Xsxy71QWqGn7HYNUvch71iV2PM7+E3uWGox1Qp90loa1ephtCxG2ftRV/Conitc6P2Q==",
+      "dev": true,
+      "requires": {
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "micromark-util-resolve-all": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-1.1.0.tgz",
+      "integrity": "sha512-b/G6BTMSg+bX+xVCshPTPyAu2tmA0E4X98NSR7eIbeC6ycCqCeE7wjfDIgzEbkzdEVJXRtOG4FbEm/uGbCRouA==",
+      "dev": true,
+      "requires": {
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "micromark-util-sanitize-uri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-1.2.0.tgz",
+      "integrity": "sha512-QO4GXv0XZfWey4pYFndLUKEAktKkG5kZTdUNaTAkzbuJxn2tNBOr+QtxR2XpWaMhbImT2dPzyLrPXLlPhph34A==",
+      "dev": true,
+      "requires": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-encode": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0"
+      }
+    },
+    "micromark-util-subtokenize": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-1.1.0.tgz",
+      "integrity": "sha512-kUQHyzRoxvZO2PuLzMt2P/dwVsTiivCK8icYTeR+3WgbuPqfHgPPy7nFKbeqRivBvn/3N3GBiNC+JRTMSxEC7A==",
+      "dev": true,
+      "requires": {
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      }
+    },
+    "micromark-util-symbol": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-1.1.0.tgz",
+      "integrity": "sha512-uEjpEYY6KMs1g7QfJ2eX1SQEV+ZT4rUD3UcF6l57acZvLNK7PBZL+ty82Z1qhK1/yXIY4bdx04FKMgR0g4IAag==",
+      "dev": true
+    },
+    "micromark-util-types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-1.1.0.tgz",
+      "integrity": "sha512-ukRBgie8TIAcacscVHSiddHjO4k/q3pnedmzMQ4iwDcK0FtFCohKOlFbaOL/mPgfnPsL3C1ZyxJa4sbWrBl3jg==",
       "dev": true
     },
     "mime": {
@@ -5687,6 +6749,12 @@
         "mkdirp": "0.5.5",
         "xml-escape": "1.1.0"
       }
+    },
+    "mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true
     },
     "ms": {
       "version": "2.1.3",
@@ -5977,6 +7045,17 @@
       "integrity": "sha512-fcOWSnnpCrovBsmFZIGIy9UqK2FaI7Hqax+DIO0A9UxeVoY4iweyaFjS5TavZN97Hfehph0nhsZnjlVKzEQSrQ==",
       "dev": true
     },
+    "prettier-plugin-jsdoc": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-jsdoc/-/prettier-plugin-jsdoc-1.0.1.tgz",
+      "integrity": "sha512-07q74MfX9m+xHK2+Lr4c+igiEzAKVDWhqkvlm65WoYJUlRiaV6STXcEtcZMhrPPYgNeQRgb9FJmgE/n+OI4MpQ==",
+      "dev": true,
+      "requires": {
+        "binary-searching": "^2.0.5",
+        "comment-parser": "^1.3.1",
+        "mdast-util-from-markdown": "^1.2.0"
+      }
+    },
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -6173,6 +7252,15 @@
       "dev": true,
       "requires": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "sade": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+      "dev": true,
+      "requires": {
+        "mri": "^1.1.0"
       }
     },
     "safe-buffer": {
@@ -6525,6 +7613,12 @@
         "underscore": "^1.12.1"
       }
     },
+    "typescript": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "dev": true
+    },
     "uc.micro": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
@@ -6536,6 +7630,15 @@
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
       "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==",
       "dev": true
+    },
+    "unist-util-stringify-position": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
+      "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "^2.0.0"
+      }
     },
     "uri-js": {
       "version": "4.4.1",
@@ -6557,6 +7660,18 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
+    },
+    "uvu": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.6.tgz",
+      "integrity": "sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==",
+      "dev": true,
+      "requires": {
+        "dequal": "^2.0.0",
+        "diff": "^5.0.0",
+        "kleur": "^4.0.3",
+        "sade": "^1.7.3"
+      }
     },
     "v8-to-istanbul": {
       "version": "9.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "mocha": "^10.2.0",
         "mocha-multi-reporters": "^1.5.1",
         "mocha-sonarqube-reporter": "^1.0.2",
-        "prettier": "^2.8.8",
+        "prettier": "^3.0.1",
         "rimraf": "^5.0.1",
         "sinon": "^15.2.0",
         "vsce": "^2.15.0"
@@ -2743,15 +2743,15 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.1.tgz",
+      "integrity": "sha512-fcOWSnnpCrovBsmFZIGIy9UqK2FaI7Hqax+DIO0A9UxeVoY4iweyaFjS5TavZN97Hfehph0nhsZnjlVKzEQSrQ==",
       "dev": true,
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
@@ -5972,9 +5972,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.1.tgz",
+      "integrity": "sha512-fcOWSnnpCrovBsmFZIGIy9UqK2FaI7Hqax+DIO0A9UxeVoY4iweyaFjS5TavZN97Hfehph0nhsZnjlVKzEQSrQ==",
       "dev": true
     },
     "process-nextick-args": {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,12 @@
             "Performs a deep merge of array-type properties overlapping in both local and shared user settings, where the arrays are combined",
             "If both the local and shared files define a value for the same array-type property, then the array value in the local file is used and the shared array value is ignored"
           ]
+        },
+        "workspaceConfigPlus.replaceMergedSymlinks": {
+          "description": "Replace a merged configuration file when it's a symlink and the content matches its shared configuration file, instead of modifying the symlink target file",
+          "type": "boolean",
+          "scope": "resource",
+          "default": false
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -126,14 +126,14 @@
     "mocha": "^10.2.0",
     "mocha-multi-reporters": "^1.5.1",
     "mocha-sonarqube-reporter": "^1.0.2",
-    "prettier": "^2.8.8",
+    "prettier": "^3.0.1",
     "rimraf": "^5.0.1",
     "sinon": "^15.2.0",
     "vsce": "^2.15.0"
   },
   "dependencies": {
-    "jsonc-parser": "^3.2.0",
-    "deepmerge": "^4.3.1"
+    "deepmerge": "^4.3.1",
+    "jsonc-parser": "^3.2.0"
   },
   "scripts": {
     "build": "npm test",

--- a/package.json
+++ b/package.json
@@ -120,6 +120,11 @@
   ],
   "devDependencies": {
     "@swellaby/eslint-config": "^2.0.0",
+    "@types/chai": "^4.3.5",
+    "@types/mocha": "^10.0.1",
+    "@types/node": "^18",
+    "@types/sinon": "^10.0.16",
+    "@types/vscode": "^1.49.0",
     "c8": "^8.0.1",
     "chai": "^4.3.7",
     "eslint": "^8.46.0",
@@ -127,8 +132,10 @@
     "mocha-multi-reporters": "^1.5.1",
     "mocha-sonarqube-reporter": "^1.0.2",
     "prettier": "^3.0.1",
+    "prettier-plugin-jsdoc": "^1.0.1",
     "rimraf": "^5.0.1",
     "sinon": "^15.2.0",
+    "typescript": "^5.1.6",
     "vsce": "^2.15.0"
   },
   "dependencies": {
@@ -136,7 +143,8 @@
     "jsonc-parser": "^3.2.0"
   },
   "scripts": {
-    "build": "npm test",
+    "build": "npm run test",
+    "build:tsc": "tsc --build",
     "clean": "rimraf .testresults .coverage .vsix",
     "coverage": "npm run coverage:unit",
     "coverage:unit": "c8 -c tests/unit/.c8rc.json npm run test:unit",

--- a/src/file-handler.js
+++ b/src/file-handler.js
@@ -107,7 +107,9 @@ const mergeConfigFiles = async ({
       { create: true, overwrite: true },
     );
   } catch (e) {
-    log.error(e.message);
+    if (e instanceof Error) {
+      log.error(e.message);
+    }
     log.debug(e);
   }
 };

--- a/src/file-handler.js
+++ b/src/file-handler.js
@@ -66,7 +66,7 @@ const mergeConfigFiles = async ({
 
     const vscodeFileContents = await loadConfigFromFile(
       vscodeFileUri,
-      readFile
+      readFile,
     );
     const merged = getMergedConfigs({ sharedConfig, localConfig });
 
@@ -79,9 +79,9 @@ const mergeConfigFiles = async ({
     await writeFile(
       vscodeFileUri,
       Buffer.from(
-        JSON.stringify({ ...vscodeFileContents, ...merged }, null, 2)
+        JSON.stringify({ ...vscodeFileContents, ...merged }, null, 2),
       ),
-      { create: true, overwrite: true }
+      { create: true, overwrite: true },
     );
   } catch (e) {
     log.error(e.message);

--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,7 @@ const activate = () => {
       joinPath,
       readFile,
       writeFile,
-    })
+    }),
   );
   workspace.onDidChangeWorkspaceFolders(({ added, removed }) =>
     handleWorkspaceFolderUpdates({
@@ -51,7 +51,7 @@ const activate = () => {
       joinPath,
       readFile,
       writeFile,
-    })
+    }),
   );
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -10,9 +10,13 @@ const {
 const {
   createFileSystemWatcher,
   createRelativePattern,
+  FileType,
   joinPath,
+  stat,
   readFile,
   writeFile,
+  delete: delete_,
+  getWorkspaceConfiguration,
 } = require('./wrappers');
 
 const activate = () => {
@@ -20,25 +24,33 @@ const activate = () => {
     return;
   }
   initializeLog(name => window.createOutputChannel(name));
-  workspace.workspaceFolders.forEach(f =>
+  for (const f of workspace.workspaceFolders) {
     initializeWorkspaceFolder({
       folderUri: f.uri,
       createFileSystemWatcher,
       createRelativePattern,
+      FileType,
       joinPath,
+      stat,
       readFile,
       writeFile,
-    }),
-  );
+      delete: delete_,
+      getWorkspaceConfiguration,
+    });
+  }
   workspace.onDidChangeWorkspaceFolders(({ added, removed }) =>
     handleWorkspaceFolderUpdates({
       added,
       removed,
       createFileSystemWatcher,
       createRelativePattern,
+      FileType,
       joinPath,
+      stat,
       readFile,
       writeFile,
+      delete: delete_,
+      getWorkspaceConfiguration,
     }),
   );
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,31 +1,19 @@
 'use strict';
 
-const { RelativePattern, Uri, workspace, window } = require('vscode');
+const { workspace, window } = require('vscode');
 const {
   deactivate,
   handleWorkspaceFolderUpdates,
   initializeLog,
   initializeWorkspaceFolder,
 } = require('./lib');
-
-// The VS Code module is only readily available within a VS Code context
-// which makes true unit testing impossible for any modules which need
-// to directly interact with the VS Code Extension APIs.
-// Accordingly, these lightweight functions are created as wrappers around
-// their respective VS Code API calls so that the core logic of this extension
-// can be tested with unit and component tests, in addition to the integration tests.
-const createFileSystemWatcher = pattern =>
-  workspace.createFileSystemWatcher(pattern);
-const createRelativePattern = (base, pattern) =>
-  new RelativePattern(base, pattern);
-const joinPath = (base, pattern) => Uri.joinPath(base, pattern);
-const readFile = fileUri =>
-  workspace.fs
-    .readFile(fileUri)
-    .then(c => c)
-    .catch(_ => {});
-const writeFile = (fileUri, contents, options) =>
-  workspace.fs.writeFile(fileUri, contents, options);
+const {
+  createFileSystemWatcher,
+  createRelativePattern,
+  joinPath,
+  readFile,
+  writeFile,
+} = require('./wrappers');
 
 const activate = () => {
   if (!workspace.workspaceFolders) {

--- a/src/lib.js
+++ b/src/lib.js
@@ -20,7 +20,7 @@ const initializeWorkspaceFolder = ({
     const localFile = `${configFile}.local`;
     const globPattern = createRelativePattern(
       workspaceVscodeDirUri,
-      `{${localFile},${sharedFile}}.json`
+      `{${localFile},${sharedFile}}.json`,
     );
     const vscodeFileUri = joinPath(workspaceVscodeDirUri, `${configFile}.json`);
     const sharedFileUri = joinPath(workspaceVscodeDirUri, `${sharedFile}.json`);
@@ -63,7 +63,7 @@ const handleWorkspaceFolderUpdates = ({
         joinPath,
         readFile,
         writeFile,
-      })
+      }),
     );
   }
   if (removed && Array.isArray(removed)) {

--- a/src/lib.js
+++ b/src/lib.js
@@ -55,9 +55,10 @@ const initializeWorkspaceFolder = ({
   });
 };
 /**
+ * @typedef {{ readonly uri: import('vscode').Uri }} WorkspaceFolder
  * @param {object} args
- * @param {readonly import('vscode').WorkspaceFolder[]} args.added
- * @param {readonly import('vscode').WorkspaceFolder[]} args.removed
+ * @param {readonly WorkspaceFolder[] | number | string} [args.added]
+ * @param {readonly WorkspaceFolder[] | number | string} [args.removed]
  * @param {import('./wrappers').createFileSystemWatcher} args.createFileSystemWatcher
  * @param {import('./wrappers').createRelativePattern} args.createRelativePattern
  * @param {import('./wrappers').joinPath} args.joinPath

--- a/src/lib.js
+++ b/src/lib.js
@@ -6,6 +6,16 @@ const log = require('./log');
 
 const workspaceConfigFileNames = ['launch', 'settings', 'tasks'];
 
+/**
+ * @param {object} args
+ * @param {import('vscode').Uri} args.folderUri
+ * @param {import('./wrappers').createFileSystemWatcher} args.createFileSystemWatcher
+ * @param {import('./wrappers').createRelativePattern} args.createRelativePattern
+ * @param {import('./wrappers').joinPath} args.joinPath
+ * @param {import('./wrappers').readFile} args.readFile
+ * @param {import('./wrappers').writeFile} args.writeFile
+ * @returns {void}
+ */
 const initializeWorkspaceFolder = ({
   folderUri,
   createFileSystemWatcher,
@@ -44,7 +54,17 @@ const initializeWorkspaceFolder = ({
     });
   });
 };
-
+/**
+ * @param {object} args
+ * @param {readonly import('vscode').WorkspaceFolder[]} args.added
+ * @param {readonly import('vscode').WorkspaceFolder[]} args.removed
+ * @param {import('./wrappers').createFileSystemWatcher} args.createFileSystemWatcher
+ * @param {import('./wrappers').createRelativePattern} args.createRelativePattern
+ * @param {import('./wrappers').joinPath} args.joinPath
+ * @param {import('./wrappers').readFile} args.readFile
+ * @param {import('./wrappers').writeFile} args.writeFile
+ * @returns {void}
+ */
 const handleWorkspaceFolderUpdates = ({
   added,
   removed,
@@ -55,7 +75,7 @@ const handleWorkspaceFolderUpdates = ({
   writeFile,
 }) => {
   if (added && Array.isArray(added)) {
-    added.forEach(f =>
+    for (const f of /** @type {WorkspaceFolder[]} */ (added)) {
       module.exports.initializeWorkspaceFolder({
         folderUri: f.uri,
         createFileSystemWatcher,
@@ -63,18 +83,25 @@ const handleWorkspaceFolderUpdates = ({
         joinPath,
         readFile,
         writeFile,
-      }),
-    );
+      });
+    }
   }
   if (removed && Array.isArray(removed)) {
-    removed.forEach(f => watcher.disposeWorkspaceWatcher(f.uri));
+    for (const f of /** @type {WorkspaceFolder[]} */ (removed)) {
+      watcher.disposeWorkspaceWatcher(f.uri);
+    }
   }
 };
 
+/**
+ * @param {(name: string) => import('vscode').OutputChannel} createOutputChannel
+ * @returns {void}
+ */
 const initializeLog = createOutputChannel => {
   log.initialize(createOutputChannel);
 };
 
+/** @returns {void} */
 const deactivate = () => {
   log.info('Deactivating and disposing all watchers');
   watcher.disposeAllWatchers();

--- a/src/lib.js
+++ b/src/lib.js
@@ -11,9 +11,13 @@ const workspaceConfigFileNames = ['launch', 'settings', 'tasks'];
  * @param {import('vscode').Uri} args.folderUri
  * @param {import('./wrappers').createFileSystemWatcher} args.createFileSystemWatcher
  * @param {import('./wrappers').createRelativePattern} args.createRelativePattern
+ * @param {typeof import('./wrappers').FileType} args.FileType
  * @param {import('./wrappers').joinPath} args.joinPath
+ * @param {import('./wrappers').stat} args.stat
  * @param {import('./wrappers').readFile} args.readFile
  * @param {import('./wrappers').writeFile} args.writeFile
+ * @param {import('./wrappers').delete} args.delete
+ * @param {import('./wrappers').getWorkspaceConfiguration} args.getWorkspaceConfiguration
  * @returns {void}
  */
 const initializeWorkspaceFolder = ({
@@ -21,10 +25,14 @@ const initializeWorkspaceFolder = ({
   createFileSystemWatcher,
   createRelativePattern,
   joinPath,
+  FileType,
+  stat,
   readFile,
   writeFile,
+  delete: delete_,
+  getWorkspaceConfiguration,
 }) => {
-  workspaceConfigFileNames.forEach(configFile => {
+  for (const configFile of workspaceConfigFileNames) {
     const workspaceVscodeDirUri = joinPath(folderUri, '.vscode');
     const sharedFile = `${configFile}.shared`;
     const localFile = `${configFile}.local`;
@@ -38,8 +46,12 @@ const initializeWorkspaceFolder = ({
     watcher.generateFileSystemWatcher({
       globPattern,
       createFileSystemWatcher,
+      FileType,
+      stat,
       readFile,
       writeFile,
+      delete: delete_,
+      getWorkspaceConfiguration,
       folderUri,
       vscodeFileUri,
       sharedFileUri,
@@ -49,10 +61,14 @@ const initializeWorkspaceFolder = ({
       vscodeFileUri,
       sharedFileUri,
       localFileUri,
+      FileType,
+      stat,
       readFile,
       writeFile,
+      delete: delete_,
+      getWorkspaceConfiguration,
     });
-  });
+  }
 };
 /**
  * @typedef {{ readonly uri: import('vscode').Uri }} WorkspaceFolder
@@ -61,9 +77,13 @@ const initializeWorkspaceFolder = ({
  * @param {readonly WorkspaceFolder[] | number | string} [args.removed]
  * @param {import('./wrappers').createFileSystemWatcher} args.createFileSystemWatcher
  * @param {import('./wrappers').createRelativePattern} args.createRelativePattern
+ * @param {typeof import('./wrappers').FileType} args.FileType
  * @param {import('./wrappers').joinPath} args.joinPath
+ * @param {import('./wrappers').stat} args.stat
  * @param {import('./wrappers').readFile} args.readFile
  * @param {import('./wrappers').writeFile} args.writeFile
+ * @param {import('./wrappers').delete} args.delete
+ * @param {import('./wrappers').getWorkspaceConfiguration} args.getWorkspaceConfiguration
  * @returns {void}
  */
 const handleWorkspaceFolderUpdates = ({
@@ -71,9 +91,13 @@ const handleWorkspaceFolderUpdates = ({
   removed,
   createFileSystemWatcher,
   createRelativePattern,
+  FileType,
   joinPath,
+  stat,
   readFile,
   writeFile,
+  delete: delete_,
+  getWorkspaceConfiguration,
 }) => {
   if (added && Array.isArray(added)) {
     for (const f of /** @type {WorkspaceFolder[]} */ (added)) {
@@ -82,8 +106,12 @@ const handleWorkspaceFolderUpdates = ({
         createFileSystemWatcher,
         createRelativePattern,
         joinPath,
+        FileType,
+        stat,
         readFile,
         writeFile,
+        delete: delete_,
+        getWorkspaceConfiguration,
       });
     }
   }

--- a/src/log.js
+++ b/src/log.js
@@ -1,7 +1,13 @@
 'use strict';
 
+/** @type {import('vscode').OutputChannel} */
 let _outputChannel;
 
+/**
+ * @param {any} msg
+ * @param {string} logLevel
+ * @returns {void}
+ */
 const write = (msg, logLevel) => {
   const dateString = new Date().toLocaleString('sv');
   module.exports._outputChannel.appendLine(
@@ -9,22 +15,42 @@ const write = (msg, logLevel) => {
   );
 };
 
+/**
+ * @param {any} msg
+ * @returns {void}
+ */
 const debug = msg => {
   write(msg, 'DEBUG');
 };
 
+/**
+ * @param {any} msg
+ * @returns {void}
+ */
 const error = msg => {
   write(msg, 'ERROR');
 };
 
+/**
+ * @param {any} msg
+ * @returns {void}
+ */
 const info = msg => {
   write(msg, 'INFO');
 };
 
+/**
+ * @param {any} msg
+ * @returns {void}
+ */
 const warn = msg => {
   write(msg, 'WARN');
 };
 
+/**
+ * @param {(name: string) => import('vscode').OutputChannel} createChannel
+ * @returns {void}
+ */
 const initialize = createChannel => {
   module.exports._outputChannel = createChannel('Workspace Config+');
 };

--- a/src/log.js
+++ b/src/log.js
@@ -1,7 +1,9 @@
 'use strict';
 
-/** @type {import('vscode').OutputChannel} */
-let _outputChannel;
+let _privateState = {
+  /** @type {import('vscode').OutputChannel | undefined} */
+  outputChannel: undefined,
+};
 
 /**
  * @param {any} msg
@@ -10,9 +12,9 @@ let _outputChannel;
  */
 const write = (msg, logLevel) => {
   const dateString = new Date().toLocaleString('sv');
-  module.exports._outputChannel.appendLine(
-    `[${dateString}] [${logLevel}] ${msg}`,
-  );
+  const { outputChannel } = _privateState;
+  if (outputChannel === undefined) throw new Error('log is uninitialized');
+  outputChannel.appendLine(`[${dateString}] [${logLevel}] ${msg}`);
 };
 
 /**
@@ -52,11 +54,14 @@ const warn = msg => {
  * @returns {void}
  */
 const initialize = createChannel => {
-  module.exports._outputChannel = createChannel('Workspace Config+');
+  _privateState.outputChannel = createChannel('Workspace Config+');
 };
 
 const dispose = () => {
-  module.exports._outputChannel.dispose();
+  const { outputChannel } = _privateState;
+  if (outputChannel !== undefined) {
+    outputChannel.dispose();
+  }
 };
 
 module.exports = {
@@ -66,6 +71,6 @@ module.exports = {
   warn,
   initialize,
   dispose,
-  // Private, exported for unit testing
-  _outputChannel,
+  // Exported for unit testing
+  _privateState,
 };

--- a/src/log.js
+++ b/src/log.js
@@ -5,7 +5,7 @@ let _outputChannel;
 const write = (msg, logLevel) => {
   const dateString = new Date().toLocaleString('sv');
   module.exports._outputChannel.appendLine(
-    `[${dateString}] [${logLevel}] ${msg}`
+    `[${dateString}] [${logLevel}] ${msg}`,
   );
 };
 

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "composite": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "forceConsistentCasingInFileNames": true,
+    "lib": ["ES2020"],
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "noEmitOnError": false,
+    "removeComments": false,
+    "sourceMap": true,
+    "strict": true,
+    "strictFunctionTypes": true,
+    "target": "ES2020",
+    "types": ["node"]
+  },
+  "extends": ["../base.tsconfig.json"],
+  "include": ["."],
+  "references": []
+}

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -8,7 +8,7 @@ const _registerSharedFileSystemWatcher = (
   globPattern,
   createFileSystemWatcher,
   workspaceUri,
-  onFileSystemEventHandler
+  onFileSystemEventHandler,
 ) => {
   const fileSystemChangeWatcher = createFileSystemWatcher(globPattern);
   module.exports._fileSystemWatchers[workspaceUri] = [
@@ -53,7 +53,7 @@ const generateFileSystemWatcher = ({
     globPattern,
     createFileSystemWatcher,
     folderUri,
-    handleFileEvent
+    handleFileEvent,
   );
 };
 

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -2,8 +2,16 @@
 
 const fileHandler = require('./file-handler');
 
+/** @type {{ [index: string]: import('vscode').Disposable[] }} */
 const _fileSystemWatchers = {};
 
+/**
+ * @param {import('vscode').GlobPattern} globPattern
+ * @param {import('./wrappers').createFileSystemWatcher} createFileSystemWatcher
+ * @param {import('vscode').Uri} workspaceUri
+ * @param {(e: import('vscode').Uri) => any} onFileSystemEventHandler
+ * @returns {void}
+ */
 const _registerSharedFileSystemWatcher = (
   globPattern,
   createFileSystemWatcher,
@@ -18,6 +26,18 @@ const _registerSharedFileSystemWatcher = (
   ];
 };
 
+/**
+ * @param {object} args
+ * @param {import('vscode').GlobPattern} args.globPattern
+ * @param {import('./wrappers').createFileSystemWatcher} args.createFileSystemWatcher
+ * @param {import('./wrappers').readFile} args.readFile
+ * @param {import('./wrappers').writeFile} args.writeFile
+ * @param {import('vscode').Uri} args.folderUri
+ * @param {import('vscode').Uri} args.vscodeFileUri
+ * @param {import('vscode').Uri} args.sharedFileUri
+ * @param {import('vscode').Uri} args.localFileUri
+ * @returns {void}
+ */
 const generateFileSystemWatcher = ({
   globPattern,
   createFileSystemWatcher,
@@ -28,7 +48,12 @@ const generateFileSystemWatcher = ({
   sharedFileUri,
   localFileUri,
 }) => {
+  /** @type {{ [index: string]: { prior: number } }} */
   const cache = {};
+  /**
+   * @param {import('vscode').Uri} e
+   * @returns {Promise<void>}
+   */
   async function handleFileEvent(e) {
     const current = new Date().valueOf();
     let entry = cache[e];
@@ -57,12 +82,17 @@ const generateFileSystemWatcher = ({
   );
 };
 
+/**
+ * @param {import('vscode').Uri} workspaceUri
+ * @returns {void}
+ */
 const disposeWorkspaceWatcher = workspaceUri => {
   if (module.exports._fileSystemWatchers[workspaceUri]) {
     module.exports._fileSystemWatchers[workspaceUri].forEach(w => w.dispose());
   }
 };
 
+/** @returns {void} */
 const disposeAllWatchers = () => {
   Object.values(module.exports._fileSystemWatchers).forEach(watchers => {
     watchers.forEach(w => w.dispose());

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -32,8 +32,12 @@ const _registerSharedFileSystemWatcher = (
  * @param {object} args
  * @param {import('vscode').GlobPattern} args.globPattern
  * @param {import('./wrappers').createFileSystemWatcher} args.createFileSystemWatcher
+ * @param {typeof import('./wrappers').FileType} args.FileType
+ * @param {import('./wrappers').stat} args.stat
  * @param {import('./wrappers').readFile} args.readFile
  * @param {import('./wrappers').writeFile} args.writeFile
+ * @param {import('./wrappers').delete} args.delete
+ * @param {import('./wrappers').getWorkspaceConfiguration} args.getWorkspaceConfiguration
  * @param {import('vscode').Uri} args.folderUri
  * @param {import('vscode').Uri} args.vscodeFileUri
  * @param {import('vscode').Uri} args.sharedFileUri
@@ -43,8 +47,12 @@ const _registerSharedFileSystemWatcher = (
 const generateFileSystemWatcher = ({
   globPattern,
   createFileSystemWatcher,
+  FileType,
+  stat,
   readFile,
   writeFile,
+  delete: delete_,
+  getWorkspaceConfiguration,
   folderUri,
   vscodeFileUri,
   sharedFileUri,
@@ -70,8 +78,12 @@ const generateFileSystemWatcher = ({
         vscodeFileUri,
         sharedFileUri,
         localFileUri,
+        FileType,
+        stat,
         readFile,
         writeFile,
+        delete: delete_,
+        getWorkspaceConfiguration,
       });
     }
     cache[`${e}`] = { prior: current };
@@ -90,17 +102,18 @@ const generateFileSystemWatcher = ({
  */
 const disposeWorkspaceWatcher = workspaceUri => {
   if (_privateState.fileSystemWatchers[`${workspaceUri}`]) {
-    _privateState.fileSystemWatchers[`${workspaceUri}`].forEach(w =>
-      w.dispose(),
-    );
+    for (const w of _privateState.fileSystemWatchers[`${workspaceUri}`])
+      w.dispose();
   }
 };
 
 /** @returns {void} */
 const disposeAllWatchers = () => {
-  Object.values(_privateState.fileSystemWatchers).forEach(watchers => {
-    watchers.forEach(w => w.dispose());
-  });
+  for (const watchers of Object.values(_privateState.fileSystemWatchers)) {
+    for (const w of watchers) {
+      w.dispose();
+    }
+  }
 };
 
 module.exports = {

--- a/src/wrappers.js
+++ b/src/wrappers.js
@@ -39,23 +39,32 @@ const joinPath = (base, pattern) => Uri.joinPath(base, pattern);
  * @returns {Thenable<Uint8Array>}
  */
 const readFile = fileUri =>
-  workspace.fs
-    .readFile(fileUri)
-    .then(c => c)
-    .catch(/** @param {never} _ */ _ => {});
+  workspace.fs.readFile(fileUri).then(
+    c => c,
+    _ => {},
+  );
 /**
  * @typedef {{
  *   readonly create?: boolean;
  *   readonly overwrite?: boolean;
  * }} writeFile.Options
- *
  * @param {Uri} fileUri
  * @param {Uint8Array} contents
  * @param {writeFile.Options} [options]
  * @returns {Thenable<void>}
  */
-const writeFile = (fileUri, contents, options) =>
-  workspace.fs.writeFile(fileUri, contents, options);
+const writeFile = (fileUri, contents, options) => {
+  // `options` is undocumented and inconsistently implemented.
+  return (
+    /**
+     * @type {(
+     *   uri: Uri,
+     *   content: Uint8Array,
+     *   options?: writeFile.Options,
+     * ) => Thenable<void>}
+     */ (workspace.fs.writeFile)(fileUri, contents, options)
+  );
+};
 
 module.exports = {
   createFileSystemWatcher,

--- a/src/wrappers.js
+++ b/src/wrappers.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { RelativePattern, Uri, workspace } = require('vscode');
+const { FileType, RelativePattern, Uri, workspace } = require('vscode');
 
 /**
  * Wrappers of VS Code Extension API functions.
@@ -35,6 +35,11 @@ const createRelativePattern = (base, pattern) =>
  */
 const joinPath = (base, pattern) => Uri.joinPath(base, pattern);
 /**
+ * @param {Uri} uri
+ * @returns {Thenable<import('vscode').FileStat>}
+ */
+const stat = uri => workspace.fs.stat(uri);
+/**
  * @param {Uri} fileUri
  * @returns {Thenable<Uint8Array>}
  */
@@ -65,11 +70,33 @@ const writeFile = (fileUri, contents, options) => {
      */ (workspace.fs.writeFile)(fileUri, contents, options)
   );
 };
+/**
+ * @typedef {object} delete_.Options
+ * @property {boolean} [delete_.Options.recursive]
+ * @property {boolean} [delete_.Options.useTrash]
+ * @param {Uri} uri
+ * @param {delete_.Options} [options]
+ * @returns {Thenable<void>}
+ */
+const delete_ = (uri, options) => workspace.fs.delete(uri, options);
+/**
+ * @template T
+ * @param {string} section
+ * @param {T} defaultValue
+ * @param {import('vscode').ConfigurationScope | null} [scope]
+ * @returns {T}
+ */
+const getWorkspaceConfiguration = (section, defaultValue, scope) =>
+  workspace.getConfiguration(undefined, scope).get(section, defaultValue);
 
 module.exports = {
   createFileSystemWatcher,
   createRelativePattern,
+  FileType,
   joinPath,
+  stat,
   readFile,
   writeFile,
+  delete: delete_,
+  getWorkspaceConfiguration,
 };

--- a/src/wrappers.js
+++ b/src/wrappers.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const { RelativePattern, Uri, workspace } = require('vscode');
+
+/**
+ * Wrappers of VS Code Extension API functions.
+ *
+ * The VS Code module is only readily available within a VS Code context which
+ * makes true unit testing impossible for any modules which need to directly
+ * interact with the VS Code Extension APIs. Accordingly, these lightweight
+ * functions are created as wrappers around their respective VS Code API calls
+ * so that the core logic of this extension can be tested with unit and
+ * component tests, in addition to the integration tests.
+ *
+ * @module
+ */
+
+/**
+ * @param {import('vscode').GlobPattern} pattern
+ * @returns {import('vscode').FileSystemWatcher}
+ */
+const createFileSystemWatcher = pattern =>
+  workspace.createFileSystemWatcher(pattern);
+/**
+ * @param {string | import('vscode').WorkspaceFolder | Uri} base
+ * @param {string} pattern
+ * @returns {import('vscode').RelativePattern}
+ */
+const createRelativePattern = (base, pattern) =>
+  new RelativePattern(base, pattern);
+/**
+ * @param {Uri} base
+ * @param {string} pattern
+ * @returns {Uri}
+ */
+const joinPath = (base, pattern) => Uri.joinPath(base, pattern);
+/**
+ * @param {Uri} fileUri
+ * @returns {Thenable<Uint8Array>}
+ */
+const readFile = fileUri =>
+  workspace.fs
+    .readFile(fileUri)
+    .then(c => c)
+    .catch(/** @param {never} _ */ _ => {});
+/**
+ * @typedef {{
+ *   readonly create?: boolean;
+ *   readonly overwrite?: boolean;
+ * }} writeFile.Options
+ *
+ * @param {Uri} fileUri
+ * @param {Uint8Array} contents
+ * @param {writeFile.Options} [options]
+ * @returns {Thenable<void>}
+ */
+const writeFile = (fileUri, contents, options) =>
+  workspace.fs.writeFile(fileUri, contents, options);
+
+module.exports = {
+  createFileSystemWatcher,
+  createRelativePattern,
+  joinPath,
+  readFile,
+  writeFile,
+};

--- a/tests/data.js
+++ b/tests/data.js
@@ -8,7 +8,31 @@ const createRelativePattern =
   /** @type {import('../src/wrappers').createRelativePattern} */ (
     /** @type {unknown} */ (() => undefined)
   );
+/**
+ * @enum {import('../src/wrappers').FileType}
+ */
+const FileType = {
+  /**
+   * The file type is unknown.
+   */
+  Unknown: 0,
+  /**
+   * A regular file.
+   */
+  File: 1,
+  /**
+   * A directory.
+   */
+  Directory: 2,
+  /**
+   * A symbolic link to a file.
+   */
+  SymbolicLink: 64,
+};
 const joinPath = /** @type {import('../src/wrappers').joinPath} */ (
+  /** @type {unknown} */ (() => undefined)
+);
+const stat = /** @type {import('../src/wrappers').stat} */ (
   /** @type {unknown} */ (() => undefined)
 );
 const readFile = /** @type {import('../src/wrappers').readFile} */ (
@@ -17,12 +41,22 @@ const readFile = /** @type {import('../src/wrappers').readFile} */ (
 const writeFile = /** @type {import('../src/wrappers').writeFile} */ (
   /** @type {unknown} */ (() => undefined)
 );
+const delete_ = /** @type {import('../src/wrappers').delete} */ (
+  /** @type {unknown} */ (() => undefined)
+);
+const getWorkspaceConfiguration = /** @type {import('../src/wrappers').getWorkspaceConfiguration} */ (
+  /** @type {unknown} */ (() => undefined)
+);
 const callbacks = {
   createFileSystemWatcher,
   createRelativePattern,
+  FileType,
+  stat,
   joinPath,
   readFile,
   writeFile,
+  delete: delete_,
+  getWorkspaceConfiguration,
 };
 
 const vscodeFileUri =

--- a/tests/data.js
+++ b/tests/data.js
@@ -1,26 +1,22 @@
 'use strict';
 
-/**
- * @param {any} _a
- * @param {any} _b
- */
-const createFileSystemWatcher = (_a, _b) => {};
-/** @param {any} _c */
-const createRelativePattern = _c => {};
-/**
- * @param {any} _d
- * @param {any} _e
- * @param {any} _f
- */
-const joinPath = (_d, _e, _f) => {};
-/**
- * @param {any} _g
- * @param {any} _h
- * @param {any} _i
- * @param {any} _j
- */
-const readFile = (_g, _h, _i, _j) => {};
-const writeFile = () => {};
+const createFileSystemWatcher =
+  /** @type {import('../src/wrappers').createFileSystemWatcher} */ (
+    /** @type {unknown} */ (() => undefined)
+  );
+const createRelativePattern =
+  /** @type {import('../src/wrappers').createRelativePattern} */ (
+    /** @type {unknown} */ (() => undefined)
+  );
+const joinPath = /** @type {import('../src/wrappers').joinPath} */ (
+  /** @type {unknown} */ (() => undefined)
+);
+const readFile = /** @type {import('../src/wrappers').readFile} */ (
+  /** @type {unknown} */ (() => undefined)
+);
+const writeFile = /** @type {import('../src/wrappers').writeFile} */ (
+  /** @type {unknown} */ (() => undefined)
+);
 const callbacks = {
   createFileSystemWatcher,
   createRelativePattern,
@@ -29,17 +25,26 @@ const callbacks = {
   writeFile,
 };
 
-const vscodeFileUri = { uri: 'foo/.vscode/settings.json' };
-const sharedFileUri = { uri: 'foo/.vscode/settings.shared.json' };
-const localFileUri = { uri: 'foo/.vscode/settings.local.json' };
+const vscodeFileUri =
+  /** @type {import('vscode').Uri} */ (
+    /** @type {unknown} */ ({ uri: 'foo/.vscode/settings.json' })
+  );
+const sharedFileUri =
+  /** @type {import('vscode').Uri} */ (
+    /** @type {unknown} */ ({ uri: 'foo/.vscode/settings.shared.json' })
+  );
+const localFileUri =
+  /** @type {import('vscode').Uri} */ (
+    /** @type {unknown} */ ({ uri: 'foo/.vscode/settings.local.json' })
+  );
 const uris = {
   vscodeFileUri,
   sharedFileUri,
   localFileUri,
 };
-const globPattern = {
-  path: 'foo/.vscode/{settings.local,settings.shared}.json',
-};
+const globPattern = /** @type {import('vscode').GlobPattern} */ (
+  'foo/.vscode/{settings.local,settings.shared}.json'
+);
 
 module.exports = {
   callbacks,

--- a/tests/data.js
+++ b/tests/data.js
@@ -1,8 +1,24 @@
 'use strict';
 
+/**
+ * @param {any} _a
+ * @param {any} _b
+ */
 const createFileSystemWatcher = (_a, _b) => {};
+/** @param {any} _c */
 const createRelativePattern = _c => {};
+/**
+ * @param {any} _d
+ * @param {any} _e
+ * @param {any} _f
+ */
 const joinPath = (_d, _e, _f) => {};
+/**
+ * @param {any} _g
+ * @param {any} _h
+ * @param {any} _i
+ * @param {any} _j
+ */
 const readFile = (_g, _h, _i, _j) => {};
 const writeFile = () => {};
 const callbacks = {

--- a/tests/unit/config.js
+++ b/tests/unit/config.js
@@ -10,15 +10,15 @@ const { properties: config } = configuration;
 
 suite('config Suite', () => {
   test('Should have the correct number of configuration settings', () => {
-    assert.deepEqual(Object.keys(config).length, 1);
+    assert.deepStrictEqual(Object.keys(config).length, 2);
   });
 
   test('Should have correct config setting values for array merge behavior', () => {
     const arrayMergeConfig = config[fileHandler._arrayMergeKey];
-    assert.deepEqual(
+    assert.deepStrictEqual(
       arrayMergeConfig.default,
       fileHandler._arrayMergeDefaultValue,
     );
-    assert.deepEqual(arrayMergeConfig.enum, ['combine', 'overwrite']);
+    assert.deepStrictEqual(arrayMergeConfig.enum, ['combine', 'overwrite']);
   });
 });

--- a/tests/unit/config.js
+++ b/tests/unit/config.js
@@ -17,7 +17,7 @@ suite('config Suite', () => {
     const arrayMergeConfig = config[fileHandler._arrayMergeKey];
     assert.deepEqual(
       arrayMergeConfig.default,
-      fileHandler._arrayMergeDefaultValue
+      fileHandler._arrayMergeDefaultValue,
     );
     assert.deepEqual(arrayMergeConfig.enum, ['combine', 'overwrite']);
   });

--- a/tests/unit/file-handler.js
+++ b/tests/unit/file-handler.js
@@ -11,7 +11,10 @@ const log = require('../../src/log');
 suite('file handler Suite', () => {
   /** @type {Sinon.SinonStub} */
   let readFileStub;
-  const fileUri = { fsPath: 'projA/.vscode/settings.shared.json' };
+  /** @type {import('vscode').Uri} */
+  const fileUri = /** @type {import('vscode').Uri} */ (
+    /** @type {unknown} */ ({ fsPath: 'projA/.vscode/settings.shared.json' })
+  );
   const config = { 'window.zoomLevel': -1 };
   const contents = JSON.stringify(config);
   const buffer = Buffer.from(contents);
@@ -19,7 +22,7 @@ suite('file handler Suite', () => {
   setup(() => {
     readFileStub = Sinon.stub(callbacks, 'readFile')
       .withArgs(fileUri)
-      .callsFake(() => buffer);
+      .callsFake(async () => buffer);
   });
 
   teardown(() => {
@@ -60,10 +63,13 @@ suite('file handler Suite', () => {
         await _loadConfigFromFile(fileUri, callbacks.readFile);
         assert.fail('Should have thrown');
       } catch (e) {
-        assert.deepEqual(
-          e.message,
-          `Failed to parse contents of: ${fileUri.fsPath}`,
-        );
+        assert.instanceOf(e, Error);
+        if (e instanceof Error) {
+          assert.deepEqual(
+            e.message,
+            `Failed to parse contents of: ${fileUri.fsPath}`,
+          );
+        }
       }
     });
   });
@@ -81,9 +87,15 @@ suite('file handler Suite', () => {
     let logDebugStub;
     /** @type {Sinon.SinonStub} */
     let logErrorStub;
-    const vscodeFileUri = { fsPath: '.vscode/settings.json' };
-    const sharedFileUri = { path: '.vscode/settings.shared.json' };
-    const localFileUri = { path: '.vscode/settings.local.json' };
+    const vscodeFileUri = /** @type {import('vscode').Uri} */ ({
+      fsPath: '.vscode/settings.json',
+    });
+    const sharedFileUri = /** @type {import('vscode').Uri} */ ({
+      path: '.vscode/settings.shared.json',
+    });
+    const localFileUri = /** @type {import('vscode').Uri} */ ({
+      path: '.vscode/settings.local.json',
+    });
     const mergeConfigFiles = fileHandler.mergeConfigFiles;
     const vscodeConfig = {
       foo: 'abc',

--- a/tests/unit/file-handler.js
+++ b/tests/unit/file-handler.js
@@ -40,7 +40,7 @@ suite('file handler Suite', () => {
     test('Should return undefined when file does not exist', async () => {
       readFileStub.callsFake(() => undefined);
       assert.isUndefined(
-        await _loadConfigFromFile(fileUri, callbacks.readFile)
+        await _loadConfigFromFile(fileUri, callbacks.readFile),
       );
       assert.isFalse(parseStub.called);
     });
@@ -48,7 +48,7 @@ suite('file handler Suite', () => {
     test('Should return config object on valid json/jsonc', async () => {
       assert.deepEqual(
         await _loadConfigFromFile(fileUri, callbacks.readFile),
-        config
+        config,
       );
     });
 
@@ -62,7 +62,7 @@ suite('file handler Suite', () => {
       } catch (e) {
         assert.deepEqual(
           e.message,
-          `Failed to parse contents of: ${fileUri.fsPath}`
+          `Failed to parse contents of: ${fileUri.fsPath}`,
         );
       }
     });
@@ -128,7 +128,7 @@ suite('file handler Suite', () => {
       ...expArrayCombineConfig,
     };
     const expArrayCombineConfigNoExplicitMerge = JSON.parse(
-      JSON.stringify(finalExpArrayCombineConfig)
+      JSON.stringify(finalExpArrayCombineConfig),
     );
     delete expArrayCombineConfigNoExplicitMerge[fileHandler._arrayMergeKey];
 
@@ -144,7 +144,7 @@ suite('file handler Suite', () => {
       [fileHandler._arrayMergeKey]: 'OVERwrite',
     };
     const sharedConfigNoArrayMerge = JSON.parse(
-      JSON.stringify(sharedArrayOverwriteConfig)
+      JSON.stringify(sharedArrayOverwriteConfig),
     );
     delete sharedConfigNoArrayMerge[fileHandler._arrayMergeKey];
     const localArrayOverwriteConfig = {
@@ -159,7 +159,7 @@ suite('file handler Suite', () => {
       baz: false,
     };
     const localConfigNoArrayMerge = JSON.parse(
-      JSON.stringify(localArrayOverwriteConfig)
+      JSON.stringify(localArrayOverwriteConfig),
     );
     delete localConfigNoArrayMerge[fileHandler._arrayMergeKey];
     const expArrayOverwriteConfig = {
@@ -180,7 +180,7 @@ suite('file handler Suite', () => {
       loadConfigFromFileStub = Sinon.stub(fileHandler, '_loadConfigFromFile');
       loadVSConfigFromFileStub = loadConfigFromFileStub.withArgs(
         vscodeFileUri,
-        callbacks.readFile
+        callbacks.readFile,
       );
       loadConfigFromFileStub
         .withArgs(sharedFileUri, callbacks.readFile)
@@ -240,8 +240,8 @@ suite('file handler Suite', () => {
       assert.isTrue(loadConfigFromFileStub.calledThrice);
       assert.isTrue(
         logInfoStub.calledOnceWithExactly(
-          `Updating config in ${vscodeFileUri.fsPath}`
-        )
+          `Updating config in ${vscodeFileUri.fsPath}`,
+        ),
       );
       assert.isTrue(
         writeFileStub.calledOnceWithExactly(
@@ -250,11 +250,11 @@ suite('file handler Suite', () => {
             JSON.stringify(
               { ...vscodeConfig, ...sharedArrayCombineConfig },
               null,
-              2
-            )
+              2,
+            ),
           ),
-          { create: true, overwrite: true }
-        )
+          { create: true, overwrite: true },
+        ),
       );
     });
 
@@ -271,8 +271,8 @@ suite('file handler Suite', () => {
       assert.isTrue(loadConfigFromFileStub.calledThrice);
       assert.isTrue(
         logInfoStub.calledOnceWithExactly(
-          `Updating config in ${vscodeFileUri.fsPath}`
-        )
+          `Updating config in ${vscodeFileUri.fsPath}`,
+        ),
       );
       assert.isTrue(
         writeFileStub.calledOnceWithExactly(
@@ -281,11 +281,11 @@ suite('file handler Suite', () => {
             JSON.stringify(
               { ...vscodeConfig, ...localArrayCombineConfig },
               null,
-              2
-            )
+              2,
+            ),
           ),
-          { create: true, overwrite: true }
-        )
+          { create: true, overwrite: true },
+        ),
       );
     });
 
@@ -299,15 +299,15 @@ suite('file handler Suite', () => {
       assert.isTrue(loadConfigFromFileStub.calledThrice);
       assert.isTrue(
         logInfoStub.calledOnceWithExactly(
-          `Updating config in ${vscodeFileUri.fsPath}`
-        )
+          `Updating config in ${vscodeFileUri.fsPath}`,
+        ),
       );
       assert.isTrue(
         writeFileStub.calledOnceWithExactly(
           vscodeFileUri,
           Buffer.from(JSON.stringify(finalExpArrayCombineConfig, null, 2)),
-          { create: true, overwrite: true }
-        )
+          { create: true, overwrite: true },
+        ),
       );
     });
 
@@ -327,15 +327,15 @@ suite('file handler Suite', () => {
       assert.isTrue(loadConfigFromFileStub.calledThrice);
       assert.isTrue(
         logInfoStub.calledOnceWithExactly(
-          `Updating config in ${vscodeFileUri.fsPath}`
-        )
+          `Updating config in ${vscodeFileUri.fsPath}`,
+        ),
       );
       assert.isTrue(
         writeFileStub.calledOnceWithExactly(
           vscodeFileUri,
           Buffer.from(JSON.stringify(finalExpArrayCombineConfig, null, 2)),
-          { create: true, overwrite: true }
-        )
+          { create: true, overwrite: true },
+        ),
       );
     });
 
@@ -352,15 +352,15 @@ suite('file handler Suite', () => {
       assert.isTrue(loadConfigFromFileStub.calledThrice);
       assert.isTrue(
         logInfoStub.calledOnceWithExactly(
-          `Updating config in ${vscodeFileUri.fsPath}`
-        )
+          `Updating config in ${vscodeFileUri.fsPath}`,
+        ),
       );
       assert.isTrue(
         writeFileStub.calledOnceWithExactly(
           vscodeFileUri,
           Buffer.from(JSON.stringify(expArrayOverwriteConfig, null, 2)),
-          { create: true, overwrite: true }
-        )
+          { create: true, overwrite: true },
+        ),
       );
     });
 
@@ -380,17 +380,17 @@ suite('file handler Suite', () => {
       assert.isTrue(loadConfigFromFileStub.calledThrice);
       assert.isTrue(
         logInfoStub.calledOnceWithExactly(
-          `Updating config in ${vscodeFileUri.fsPath}`
-        )
+          `Updating config in ${vscodeFileUri.fsPath}`,
+        ),
       );
       assert.isTrue(
         writeFileStub.calledOnceWithExactly(
           vscodeFileUri,
           Buffer.from(
-            JSON.stringify(expArrayCombineConfigNoExplicitMerge, null, 2)
+            JSON.stringify(expArrayCombineConfigNoExplicitMerge, null, 2),
           ),
-          { create: true, overwrite: true }
-        )
+          { create: true, overwrite: true },
+        ),
       );
     });
 
@@ -399,11 +399,11 @@ suite('file handler Suite', () => {
         return Promise.resolve(finalExpArrayCombineConfig);
       });
       const updatedLocalConfig = JSON.parse(
-        JSON.stringify(localArrayCombineConfig)
+        JSON.stringify(localArrayCombineConfig),
       );
       updatedLocalConfig.cow = 'moo';
       const secondExpectedConfig = JSON.parse(
-        JSON.stringify(finalExpArrayCombineConfig)
+        JSON.stringify(finalExpArrayCombineConfig),
       );
       secondExpectedConfig.cow = 'moo';
       loadConfigFromFileStub
@@ -426,22 +426,22 @@ suite('file handler Suite', () => {
       assert.deepEqual(loadConfigFromFileStub.callCount, 6);
       assert.isTrue(logInfoStub.calledTwice);
       assert.isTrue(
-        logInfoStub.calledWith(`Updating config in ${vscodeFileUri.fsPath}`)
+        logInfoStub.calledWith(`Updating config in ${vscodeFileUri.fsPath}`),
       );
       assert.isTrue(writeFileStub.calledTwice);
       assert.isTrue(
         writeFileStub.firstCall.calledWithExactly(
           vscodeFileUri,
           Buffer.from(JSON.stringify(finalExpArrayCombineConfig, null, 2)),
-          { create: true, overwrite: true }
-        )
+          { create: true, overwrite: true },
+        ),
       );
       assert.isTrue(
         writeFileStub.secondCall.calledWithExactly(
           vscodeFileUri,
           Buffer.from(JSON.stringify(secondExpectedConfig, null, 2)),
-          { create: true, overwrite: true }
-        )
+          { create: true, overwrite: true },
+        ),
       );
     });
 
@@ -461,7 +461,7 @@ suite('file handler Suite', () => {
     test('Throws correct error on invalid type for array merge behavior', async () => {
       const arrayMerge = 2;
       const invalidArrayMergeTypeConfig = JSON.parse(
-        JSON.stringify(localArrayCombineConfig)
+        JSON.stringify(localArrayCombineConfig),
       );
       invalidArrayMergeTypeConfig[fileHandler._arrayMergeKey] = arrayMerge;
       loadConfigFromFileStub
@@ -480,7 +480,7 @@ suite('file handler Suite', () => {
     test('Throws correct error on invalid value for array merge behavior', async () => {
       const arrayMerge = 'shuffle';
       const invalidArrayMergeValueConfig = JSON.parse(
-        JSON.stringify(localArrayCombineConfig)
+        JSON.stringify(localArrayCombineConfig),
       );
       invalidArrayMergeValueConfig[fileHandler._arrayMergeKey] = arrayMerge;
       loadConfigFromFileStub

--- a/tests/unit/lib.js
+++ b/tests/unit/lib.js
@@ -48,21 +48,29 @@ suite('lib Suite', () => {
     });
 
     test('Should handle falsy value for added folders', () => {
-      lib.handleWorkspaceFolderUpdates({});
+      lib.handleWorkspaceFolderUpdates({ ...data.callbacks });
       assert.isFalse(initializeWorkspaceFolderStub.called);
     });
 
     test('Should handle non-array value for added folders', () => {
-      lib.handleWorkspaceFolderUpdates({ added: 7 });
+      lib.handleWorkspaceFolderUpdates({ added: 7, ...data.callbacks });
       assert.isFalse(initializeWorkspaceFolderStub.called);
     });
 
     test('Should properly initialize added folders', () => {
-      const added = [{ uri: 'foo/bar' }, { uri: 'baz/qux' }];
-      lib.handleWorkspaceFolderUpdates({
-        added,
-        ...data.callbacks,
-      });
+      const added = [
+        {
+          uri: /** @type {import('vscode').Uri} */ (
+            /** @type {unknown} */ ('foo/bar')
+          ),
+        },
+        {
+          uri: /** @type {import('vscode').Uri} */ (
+            /** @type {unknown} */ ('baz/qux')
+          ),
+        },
+      ];
+      lib.handleWorkspaceFolderUpdates({ added, ...data.callbacks });
       assert.deepEqual(initializeWorkspaceFolderStub.firstCall.firstArg, {
         folderUri: added[0].uri,
         ...data.callbacks,
@@ -70,18 +78,29 @@ suite('lib Suite', () => {
     });
 
     test('Should handle falsy value for removed folders', () => {
-      lib.handleWorkspaceFolderUpdates({});
+      lib.handleWorkspaceFolderUpdates({ ...data.callbacks });
       assert.isFalse(disposeWorkspaceWatcherStub.called);
     });
 
     test('Should handle non-array value for removed folders', () => {
-      lib.handleWorkspaceFolderUpdates({ removed: 'why' });
+      lib.handleWorkspaceFolderUpdates({ removed: 'why', ...data.callbacks });
       assert.isFalse(initializeWorkspaceFolderStub.called);
     });
 
     test('Should properly handle removed folders', () => {
-      const removed = [{ uri: 'bar/foo' }, { uri: 'qux/baz' }];
-      lib.handleWorkspaceFolderUpdates({ removed });
+      const removed = [
+        {
+          uri: /** @type {import('vscode').Uri} */ (
+            /** @type {unknown} */ ('bar/foo')
+          ),
+        },
+        {
+          uri: /** @type {import('vscode').Uri} */ (
+            /** @type {unknown} */ ('qux/baz')
+          ),
+        },
+      ];
+      lib.handleWorkspaceFolderUpdates({ removed, ...data.callbacks });
       assert.isTrue(disposeWorkspaceWatcherStub.calledTwice);
       assert.isTrue(
         disposeWorkspaceWatcherStub.calledWithExactly(removed[0].uri),
@@ -95,7 +114,9 @@ suite('lib Suite', () => {
   suite('initializeLog Suite', () => {
     test('Should initialize log correctly', () => {
       const createOutputChannel = () => {
-        return 7;
+        return /** @type {import('vscode').OutputChannel} */ (
+          /** @type {unknown} */ (7)
+        );
       };
       const logInitializeStub = Sinon.stub(log, 'initialize');
       lib.initializeLog(createOutputChannel);
@@ -116,9 +137,13 @@ suite('lib Suite', () => {
     let joinPathStub;
     /** @type {Sinon.SinonStub} */
     let createRelativePatternStub;
-    const workspaceVscodeDirUri = { uri: 'foo/.vscode' };
-    const folderUri = 'foo';
-    const { pattern } = data;
+    const workspaceVscodeDirUri = /** @type {import('vscode').Uri} */ (
+      /** @type {unknown} */ ({ uri: 'foo/.vscode' })
+    );
+    const folderUri = /** @type {import('vscode').Uri} */ (
+      /** @type {unknown} */ ({ uri: 'foo' })
+    );
+    const { globPattern } = data;
     const { vscodeFileUri, localFileUri, sharedFileUri } = data.uris;
 
     setup(() => {
@@ -137,6 +162,7 @@ suite('lib Suite', () => {
       );
     });
 
+    /** @param {import('vscode').GlobPattern} pattern */
     const assertGenerateWatcherCall = pattern => {
       assert.isTrue(
         generateFileSystemWatcherStub.calledWithExactly({
@@ -173,7 +199,7 @@ suite('lib Suite', () => {
           workspaceVscodeDirUri,
           '{settings.local,settings.shared}.json',
         )
-        .callsFake(() => pattern);
+        .callsFake(() => globPattern);
       joinPathStub
         .withArgs(workspaceVscodeDirUri, 'settings.json')
         .callsFake(() => vscodeFileUri);
@@ -185,14 +211,14 @@ suite('lib Suite', () => {
         .callsFake(() => localFileUri);
 
       lib.initializeWorkspaceFolder({ folderUri, ...callbacks });
-      assertGenerateWatcherCall(pattern);
+      assertGenerateWatcherCall(globPattern);
       assertMergeFilesCall();
     });
 
     test('Should initialize launch.json correctly', () => {
       createRelativePatternStub
         .withArgs(workspaceVscodeDirUri, '{launch.local,launch.shared}.json')
-        .callsFake(() => pattern);
+        .callsFake(() => globPattern);
       joinPathStub
         .withArgs(workspaceVscodeDirUri, 'launch.json')
         .callsFake(() => vscodeFileUri);
@@ -204,14 +230,14 @@ suite('lib Suite', () => {
         .callsFake(() => localFileUri);
 
       lib.initializeWorkspaceFolder({ folderUri, ...callbacks });
-      assertGenerateWatcherCall(pattern);
+      assertGenerateWatcherCall(globPattern);
       assertMergeFilesCall();
     });
 
     test('Should initialize tasks.json correctly', () => {
       createRelativePatternStub
         .withArgs(workspaceVscodeDirUri, '{tasks.local,tasks.shared}.json')
-        .callsFake(() => pattern);
+        .callsFake(() => globPattern);
       joinPathStub
         .withArgs(workspaceVscodeDirUri, 'tasks.json')
         .callsFake(() => vscodeFileUri);
@@ -223,7 +249,7 @@ suite('lib Suite', () => {
         .callsFake(() => localFileUri);
 
       lib.initializeWorkspaceFolder({ folderUri, ...callbacks });
-      assertGenerateWatcherCall(pattern);
+      assertGenerateWatcherCall(globPattern);
       assertMergeFilesCall();
     });
   });

--- a/tests/unit/lib.js
+++ b/tests/unit/lib.js
@@ -22,8 +22,8 @@ suite('lib Suite', () => {
       lib.deactivate();
       assert.isTrue(
         logInfoStub.calledOnceWithExactly(
-          'Deactivating and disposing all watchers'
-        )
+          'Deactivating and disposing all watchers',
+        ),
       );
       assert.isTrue(disposeAllWatchersStub.calledOnce);
       assert.isTrue(logDisposeStub.calledOnce);
@@ -39,11 +39,11 @@ suite('lib Suite', () => {
     setup(() => {
       initializeWorkspaceFolderStub = Sinon.stub(
         lib,
-        'initializeWorkspaceFolder'
+        'initializeWorkspaceFolder',
       );
       disposeWorkspaceWatcherStub = Sinon.stub(
         watcher,
-        'disposeWorkspaceWatcher'
+        'disposeWorkspaceWatcher',
       );
     });
 
@@ -84,10 +84,10 @@ suite('lib Suite', () => {
       lib.handleWorkspaceFolderUpdates({ removed });
       assert.isTrue(disposeWorkspaceWatcherStub.calledTwice);
       assert.isTrue(
-        disposeWorkspaceWatcherStub.calledWithExactly(removed[0].uri)
+        disposeWorkspaceWatcherStub.calledWithExactly(removed[0].uri),
       );
       assert.isTrue(
-        disposeWorkspaceWatcherStub.calledWithExactly(removed[1].uri)
+        disposeWorkspaceWatcherStub.calledWithExactly(removed[1].uri),
       );
     });
   });
@@ -100,7 +100,7 @@ suite('lib Suite', () => {
       const logInitializeStub = Sinon.stub(log, 'initialize');
       lib.initializeLog(createOutputChannel);
       assert.isTrue(
-        logInitializeStub.calledOnceWithExactly(createOutputChannel)
+        logInitializeStub.calledOnceWithExactly(createOutputChannel),
       );
     });
   });
@@ -124,7 +124,7 @@ suite('lib Suite', () => {
     setup(() => {
       generateFileSystemWatcherStub = Sinon.stub(
         watcher,
-        'generateFileSystemWatcher'
+        'generateFileSystemWatcher',
       );
       mergeConfigFilesStub = Sinon.stub(fileHandler, 'mergeConfigFiles');
       joinPathStub = Sinon.stub(callbacks, 'joinPath');
@@ -133,7 +133,7 @@ suite('lib Suite', () => {
         .callsFake(() => workspaceVscodeDirUri);
       createRelativePatternStub = Sinon.stub(
         callbacks,
-        'createRelativePattern'
+        'createRelativePattern',
       );
     });
 
@@ -146,7 +146,7 @@ suite('lib Suite', () => {
           createFileSystemWatcher,
           readFile,
           writeFile,
-        })
+        }),
       );
     };
 
@@ -156,7 +156,7 @@ suite('lib Suite', () => {
           ...data.uris,
           readFile,
           writeFile,
-        })
+        }),
       );
     };
 
@@ -171,7 +171,7 @@ suite('lib Suite', () => {
       createRelativePatternStub
         .withArgs(
           workspaceVscodeDirUri,
-          '{settings.local,settings.shared}.json'
+          '{settings.local,settings.shared}.json',
         )
         .callsFake(() => pattern);
       joinPathStub

--- a/tests/unit/log.js
+++ b/tests/unit/log.js
@@ -55,13 +55,13 @@ suite('log Suite', () => {
         actName = name;
         return outputChannel;
       });
-      assert.deepEqual(actName, 'Workspace Config+');
+      assert.deepStrictEqual(actName, 'Workspace Config+');
     });
 
     test('Should initialize internal channel', () => {
       const outputChannel = unimplementedOutputChannel('foo');
       log.initialize(() => outputChannel);
-      assert.deepEqual(log._privateState.outputChannel, outputChannel);
+      assert.deepStrictEqual(log._privateState.outputChannel, outputChannel);
     });
   });
 
@@ -86,7 +86,7 @@ suite('log Suite', () => {
 
     /** @param {string} level */
     const assertLogMessage = level => {
-      assert.deepEqual(`[${localString}] [${level}] ${msg}`, actLogMessage);
+      assert.deepStrictEqual(`[${localString}] [${level}] ${msg}`, actLogMessage);
     };
 
     test('Warn should set correct log level', () => {
@@ -118,7 +118,7 @@ suite('log Suite', () => {
       log._privateState.outputChannel = outputChannel;
       const stub = Sinon.stub(outputChannel, 'dispose');
       log.dispose();
-      assert.isTrue(stub.calledOnce);
+      assert.deepStrictEqual(stub.callCount, 1);
     });
   });
 });

--- a/tests/unit/log.js
+++ b/tests/unit/log.js
@@ -5,7 +5,37 @@ const Sinon = require('sinon');
 
 const log = require('../../src/log');
 
+/**
+ * @param {string} name
+ * @returns {import('vscode').OutputChannel}
+ */
+const unimplementedOutputChannel = name => ({
+  append: () => {
+    throw new Error('unimplemented');
+  },
+  appendLine: () => {
+    throw new Error('unimplemented');
+  },
+  clear: () => {
+    throw new Error('unimplemented');
+  },
+  dispose: () => {
+    throw new Error('unimplemented');
+  },
+  hide: () => {
+    throw new Error('unimplemented');
+  },
+  name,
+  replace: () => {
+    throw new Error('unimplemented');
+  },
+  show: () => {
+    throw new Error('unimplemented');
+  },
+});
+
 suite('log Suite', () => {
+  /** @type {Sinon.SinonFakeTimers} */
   let clock;
 
   setup(() => {
@@ -20,28 +50,31 @@ suite('log Suite', () => {
   suite('initialize Suite', () => {
     test('Should create output channel with correct title', () => {
       let actName = '';
+      const outputChannel = unimplementedOutputChannel('foo');
       log.initialize(name => {
         actName = name;
+        return outputChannel;
       });
       assert.deepEqual(actName, 'Workspace Config+');
     });
 
     test('Should initialize internal channel', () => {
-      const channel = { name: 'foo' };
-      log.initialize(() => channel);
-      assert.deepEqual(log._outputChannel, channel);
+      const outputChannel = unimplementedOutputChannel('foo');
+      log.initialize(() => outputChannel);
+      assert.deepEqual(log._privateState.outputChannel, outputChannel);
     });
   });
 
   suite('log levels Suite', () => {
     const msg = 'bar';
     const localString = '2021-08-15 14:16:52';
+    /** @type {string | undefined} */
     let actLogMessage;
 
     setup(() => {
-      log._outputChannel = {
-        appendLine: m => (actLogMessage = m),
-      };
+      const outputChannel = unimplementedOutputChannel('foo');
+      outputChannel.appendLine = m => (actLogMessage = m);
+      log._privateState.outputChannel = outputChannel;
       Sinon.stub(clock.Date.prototype, 'toLocaleString')
         .withArgs('sv')
         .callsFake(() => localString);
@@ -51,6 +84,7 @@ suite('log Suite', () => {
       actLogMessage = undefined;
     });
 
+    /** @param {string} level */
     const assertLogMessage = level => {
       assert.deepEqual(`[${localString}] [${level}] ${msg}`, actLogMessage);
     };
@@ -78,8 +112,11 @@ suite('log Suite', () => {
 
   suite('dispose Suite', () => {
     test('Should dispose the output channel', () => {
-      log._outputChannel = { dispose: () => {} };
-      const stub = Sinon.stub(log._outputChannel, 'dispose');
+      const outputChannel = /** @type {import('vscode').OutputChannel} */ ({
+        dispose: () => {},
+      });
+      log._privateState.outputChannel = outputChannel;
+      const stub = Sinon.stub(outputChannel, 'dispose');
       log.dispose();
       assert.isTrue(stub.calledOnce);
     });

--- a/tests/unit/tsconfig.json
+++ b/tests/unit/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "resolveJsonModule": true,
+    "types": ["node", "mocha"]
+  },
+  "extends": ["../../src/tsconfig.json"],
+  "files": ["../../package.json", "../data.js"],
+  "include": ["."],
+  "references": [{ "path": "../../src" }]
+}

--- a/tests/unit/watcher.js
+++ b/tests/unit/watcher.js
@@ -23,7 +23,7 @@ suite('watcher Suite', () => {
   let fourthWatcherDisposeStub;
 
   setup(() => {
-    watcher._fileSystemWatchers = {
+    watcher._privateState.fileSystemWatchers = {
       first: [firstWatcher, secondWatcher],
       second: [thirdWatcher, fourthWatcher],
     };
@@ -47,13 +47,16 @@ suite('watcher Suite', () => {
     // ~ 2021-08-16T20-17-50Z
     const initialTime = 1629162959014;
     const { generateFileSystemWatcher } = watcher;
-    const folderUri = 'my-project/.vscode';
+    const folderUri = /** @type {import('vscode').Uri} */ (
+      /** @type {unknown} */ ('my-project/.vscode')
+    );
     const args = {
       ...callbacks,
       ...uris,
       folderUri,
       globPattern,
     };
+    /** @type {(e: import('vscode').Uri) => any} */
     let handleFileEvent;
 
     setup(() => {
@@ -69,7 +72,9 @@ suite('watcher Suite', () => {
     });
 
     teardown(() => {
-      handleFileEvent = null;
+      handleFileEvent = /** @type {typeof handleFileEvent} */ (
+        /** @type {unknown} */ (undefined)
+      );
     });
 
     test('Should not merge twice on duplicate events in rapid succession', async () => {
@@ -101,24 +106,52 @@ suite('watcher Suite', () => {
 
   suite('_registerSharedFileSystemWatcher Suite', () => {
     /** @type {Sinon.SinonStub} */
+    // eslint-disable-next-line no-unused-vars
     let createFileSystemWatcherStub;
     /** @type {Sinon.SinonStub} */
+    // eslint-disable-next-line no-unused-vars
     let onDidChangeStub;
     /** @type {Sinon.SinonStub} */
+    // eslint-disable-next-line no-unused-vars
     let onDidCreateStub;
     /** @type {Sinon.SinonStub} */
+    // eslint-disable-next-line no-unused-vars
     let onDidDeleteStub;
-    const fileSystemWatcher = {
-      onDidChange: () => null,
-      onDidCreate: () => null,
-      onDidDelete: () => null,
-    };
-    const vsCodeUri = { uri: 'foo/.vscode' };
-    const pattern = { path: '{a,b}.json' };
-    const handleEvent = (_a, _b, _c, _d = '') => {};
-    const didChange = 'indeed';
-    const didCreate = { foo: 'bar' };
-    const didDelete = false;
+    const fileSystemWatcher =
+      /** @type {import('vscode').FileSystemWatcher} */ ({
+        dispose: () => null,
+        ignoreChangeEvents: false,
+        ignoreCreateEvents: false,
+        ignoreDeleteEvents: false,
+        onDidChange: () =>
+          /** @type {import('vscode').Disposable} */ (
+            /** @type {unknown} */ (null)
+          ),
+        onDidCreate: () =>
+          /** @type {import('vscode').Disposable} */ (
+            /** @type {unknown} */ (null)
+          ),
+        onDidDelete: () =>
+          /** @type {import('vscode').Disposable} */ (
+            /** @type {unknown} */ (null)
+          ),
+      });
+    const vscodeDirUri =
+      /** @type {import('vscode').Uri & import('vscode').WorkspaceFolder} */ (
+        /** @type {unknown} */ ({ uri: 'foo/.vscode' })
+      );
+    const pattern = /** @type {import('vscode').GlobPattern} */ ('{a,b}.json');
+    /** @type {(e: import('vscode').Uri) => any} */
+    const handleEvent = () => {};
+    const didChange = /** @type {import('vscode').Disposable} */ (
+      /** @type {unknown} */ ('indeed')
+    );
+    const didCreate = /** @type {import('vscode').Disposable} */ (
+      /** @type {unknown} */ ({ foo: 'bar' })
+    );
+    const didDelete = /** @type {import('vscode').Disposable} */ (
+      /** @type {unknown} */ (false)
+    );
 
     setup(() => {
       createFileSystemWatcherStub = Sinon.stub(
@@ -142,10 +175,10 @@ suite('watcher Suite', () => {
       watcher._registerSharedFileSystemWatcher(
         pattern,
         callbacks.createFileSystemWatcher,
-        vsCodeUri,
+        vscodeDirUri,
         handleEvent,
       );
-      assert.deepEqual(watcher._fileSystemWatchers[vsCodeUri], [
+      assert.deepEqual(watcher._privateState.fileSystemWatchers[`${vscodeDirUri}`], [
         didChange,
         didCreate,
         didDelete,
@@ -165,7 +198,9 @@ suite('watcher Suite', () => {
 
   suite('disposeWorkspaceWatcher Suite', () => {
     test('Should invoke dispose on all disposables for workspace', () => {
-      watcher.disposeWorkspaceWatcher('first');
+      watcher.disposeWorkspaceWatcher(
+        /** @type {import('vscode').Uri} */ (/** @type {unknown} */ ('first')),
+      );
       assert.isTrue(firstWatcherDisposeStub.calledOnce);
       assert.isTrue(secondWatcherDisposeStub.calledOnce);
       assert.isFalse(thirdWatcherDisposeStub.calledOnce);

--- a/tests/unit/watcher.js
+++ b/tests/unit/watcher.js
@@ -82,7 +82,7 @@ suite('watcher Suite', () => {
       await handleFileEvent(uris.sharedFileUri);
       clock.tick(349);
       await handleFileEvent(uris.sharedFileUri);
-      assert.isTrue(mergeFilesStub.calledOnce);
+      assert.deepStrictEqual(mergeFilesStub.callCount, 1);
     });
 
     test('Should merge again if same type of events happen outside the cache boundary', async () => {
@@ -90,17 +90,17 @@ suite('watcher Suite', () => {
       await handleFileEvent(uris.sharedFileUri);
       clock.tick(351);
       await handleFileEvent(uris.sharedFileUri);
-      assert.isTrue(mergeFilesStub.calledTwice);
+      assert.deepStrictEqual(mergeFilesStub.callCount, 2);
     });
 
     test('Should register watcher correctly', async () => {
       generateFileSystemWatcher(args);
-      assert.isTrue(registerSharedFileSystemWatcherStub.calledOnce);
+      assert.deepStrictEqual(registerSharedFileSystemWatcherStub.callCount, 1);
       const callArgs = registerSharedFileSystemWatcherStub.firstCall.args;
       // The fourth arg is the inner callback function, which is validated above.
-      assert.deepEqual(callArgs[0], globPattern);
-      assert.deepEqual(callArgs[1], callbacks.createFileSystemWatcher);
-      assert.deepEqual(callArgs[2], folderUri);
+      assert.deepStrictEqual(callArgs[0], globPattern);
+      assert.deepStrictEqual(callArgs[1], callbacks.createFileSystemWatcher);
+      assert.deepStrictEqual(callArgs[2], folderUri);
     });
   });
 
@@ -178,7 +178,7 @@ suite('watcher Suite', () => {
         vscodeDirUri,
         handleEvent,
       );
-      assert.deepEqual(watcher._privateState.fileSystemWatchers[`${vscodeDirUri}`], [
+      assert.deepStrictEqual(watcher._privateState.fileSystemWatchers[`${vscodeDirUri}`], [
         didChange,
         didCreate,
         didDelete,
@@ -189,10 +189,10 @@ suite('watcher Suite', () => {
   suite('disposeAllWatchers Suite', () => {
     test('Should invoke dispose on all watcher disposables', () => {
       watcher.disposeAllWatchers();
-      assert.isTrue(firstWatcherDisposeStub.calledOnce);
-      assert.isTrue(secondWatcherDisposeStub.calledOnce);
-      assert.isTrue(thirdWatcherDisposeStub.calledOnce);
-      assert.isTrue(fourthWatcherDisposeStub.calledOnce);
+      assert.deepStrictEqual(firstWatcherDisposeStub.callCount, 1);
+      assert.deepStrictEqual(secondWatcherDisposeStub.callCount, 1);
+      assert.deepStrictEqual(thirdWatcherDisposeStub.callCount, 1);
+      assert.deepStrictEqual(fourthWatcherDisposeStub.callCount, 1);
     });
   });
 
@@ -201,10 +201,10 @@ suite('watcher Suite', () => {
       watcher.disposeWorkspaceWatcher(
         /** @type {import('vscode').Uri} */ (/** @type {unknown} */ ('first')),
       );
-      assert.isTrue(firstWatcherDisposeStub.calledOnce);
-      assert.isTrue(secondWatcherDisposeStub.calledOnce);
-      assert.isFalse(thirdWatcherDisposeStub.calledOnce);
-      assert.isFalse(fourthWatcherDisposeStub.calledOnce);
+      assert.deepStrictEqual(firstWatcherDisposeStub.callCount, 1);
+      assert.deepStrictEqual(secondWatcherDisposeStub.callCount, 1);
+      assert.notStrictEqual(thirdWatcherDisposeStub.callCount, 1);
+      assert.notStrictEqual(fourthWatcherDisposeStub.callCount, 1);
     });
   });
 });

--- a/tests/unit/watcher.js
+++ b/tests/unit/watcher.js
@@ -61,7 +61,7 @@ suite('watcher Suite', () => {
       clock.tick(initialTime);
       registerSharedFileSystemWatcherStub = Sinon.stub(
         watcher,
-        '_registerSharedFileSystemWatcher'
+        '_registerSharedFileSystemWatcher',
       ).callsFake((_g, _c, _f, cb) => {
         handleFileEvent = cb;
       });
@@ -123,18 +123,18 @@ suite('watcher Suite', () => {
     setup(() => {
       createFileSystemWatcherStub = Sinon.stub(
         callbacks,
-        'createFileSystemWatcher'
+        'createFileSystemWatcher',
       )
         .withArgs(pattern)
         .callsFake(() => fileSystemWatcher);
       onDidChangeStub = Sinon.stub(fileSystemWatcher, 'onDidChange').callsFake(
-        () => didChange
+        () => didChange,
       );
       onDidCreateStub = Sinon.stub(fileSystemWatcher, 'onDidCreate').callsFake(
-        () => didCreate
+        () => didCreate,
       );
       onDidDeleteStub = Sinon.stub(fileSystemWatcher, 'onDidDelete').callsFake(
-        () => didDelete
+        () => didDelete,
       );
     });
 
@@ -143,7 +143,7 @@ suite('watcher Suite', () => {
         pattern,
         callbacks.createFileSystemWatcher,
         vsCodeUri,
-        handleEvent
+        handleEvent,
       );
       assert.deepEqual(watcher._fileSystemWatchers[vsCodeUri], [
         didChange,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "files": [],
+  "include": [],
+  "references": [{ "path": "./src" }, { "path": "./tests/unit" }]
+}


### PR DESCRIPTION
By symlinking `settings.json` to `settings.shared.json` and setting `"workspaceConfigPlus.replaceMergedSymlinks": true` in that file, users without Workspace Config+ will still use the shared settings but will also avoid modifying the shared settings once they enable the extension.

I wish I could directly check the symlink target, but VS Code doesn't support that. Note that we already pass an options argument to `workspace.fs.writeFile()`, which is private and not supported by all `workspace.fs` instances.